### PR TITLE
Ignore inconvenient messages in segment gatherer

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -374,7 +374,11 @@ class SegmentGatherer(object):
         """Process message"""
         mda = None
 
-        uid = msg.data['uid']
+        try:
+            uid = msg.data['uid']
+        except KeyError:
+            self.logger.debug("Ignoring: %s", str(msg))
+            return
 
         # Find the correct parser for this file
         key = self.key_from_fname(uid)


### PR DESCRIPTION
This PR makes segment-gatherer skip `dataset` or `collection` messages