### PR TITLE
add on_moved process to watchdog trigger.

### DIFF
--- a/pytroll_collectors/trigger.py
+++ b/pytroll_collectors/trigger.py
@@ -299,6 +299,21 @@ try:
                 LOG.exception(
                     "Something wrong happened in the event processing!")
 
+        def on_moved(self, event):
+            """On a file been moved to the destination directory.
+            """
+            try:
+                for pattern in self.patterns:
+                    if fnmatch(event.dest_path, pattern):
+                        LOG.debug(
+                            "New file detected (moved): " + event.dest_path)
+                        self.process(event.dest_path)
+                        LOG.debug("Done processing file")
+                        return
+            except:
+                LOG.exception(
+                    "Something wrong happened in the 'moved' event processing!")
+
         def process(self, pathname):
             raise NotImplementedError
 


### PR DESCRIPTION
In the case that a file has been moved to the target directory, python watchdog may only generated a 'moved' event; since there is no 'on_moved' method of the watchdogtrigger, the file will not trigger the processing even the file name matches the pattern. 

This PR is to add on_moved event process to the watchdog trigger to deal with above case.