### PR TITLE
Bugfix segment gatherer empty fileset

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -165,6 +165,8 @@ class SegmentGatherer(object):
 
         for itm in itm_str.split(','):
             channel_name, segments = itm.split(':')
+            if channel_name == '' and segments == '':
+                continue
             segments = segments.split('-')
             if len(segments) > 1:
                 format_string = '%d'

--- a/pytroll_collectors/tests/data/segments.ini
+++ b/pytroll_collectors/tests/data/segments.ini
@@ -7,3 +7,14 @@ topics = /foo/bar
 publish_topic = /pub/foo/bar
 timeliness = 900
 time_name = start_time
+
+[goes16]
+pattern = {system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}{channel_name:3s}_{orig_platform_name:3s}_s{start_time:%Y%j%H}00{start_time_seconds:%S}{start_frac_sec:1d}_e{end_time:%Y%j%H%M%S}{end_frac_sec:1d}_c{creation_time}.nc
+critical_files =
+wanted_files = C02:,C08:,C13:
+all_files = C01:,C02:,C03:,C04:,C05:,C06:,C07:,C08:,C09:,C10:,C11:,C12:,C13:,C14:,C15:,C16:
+topics = /foo/bar
+publish_topic = /pub/foo/bar
+timeliness = 1500
+time_name = start_time
+variable_tags = end_time,end_frac_sec,creation_time

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -45,6 +45,8 @@ CONFIG_DOUBLE = read_yaml(os.path.join(THIS_DIR, "data/segments_double.yaml"))
 CONFIG_NO_SEG = read_yaml(os.path.join(THIS_DIR,
                                        "data/segments_double_no_segments.yaml"))
 CONFIG_INI = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"), "msg")
+CONFIG_INI_NO_SEG = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"),
+                                "goes16")
 
 
 class TestSegmentGatherer(unittest.TestCase):
@@ -64,10 +66,23 @@ class TestSegmentGatherer(unittest.TestCase):
         self.mda_hrpt = {"uid": "hrpt_metop01_20180319_0955_28538.l1b", "platform_shortname": "metop01", "start_time": dt.datetime(2018, 3, 19, 9, 55, 0), "orbit_number":
                          28538, "uri": "/home/lahtinep/data/satellite/new/hrpt_metop01_20180319_0955_28538.l1b", "platform_name": "Metop-B", "path": "", "sensor": ["avhrr/3"]}
 
+        self.mda_goes16 = {"uid": "OR_ABI-L1b-RadF-M3C08_G16_s20190320600324_e20190320611091_c20190320611138.nc",
+                           "creation_time": "20190320611138",
+                           "start_time": dt.datetime(2019, 2, 1, 6, 0, 0),
+                           "area_code": "F", "mission_id": "ABI", "path": "",
+                           "system_environment": "OR", "scan_mode": "M3",
+                           "uri": "/path/OR_ABI-L1b-RadF-M3C08_G16_s20190320600324_e20190320611091_c20190320611138.nc",
+                           "start_seconds": dt.datetime(1900, 1, 1, 0, 0, 32, 400000),
+                           "platform_name": "GOES-16",
+                           "end_time": dt.datetime(2019, 2, 1, 6, 11, 9, 100000),
+                           "orig_platform_name": "G16", "dataset_name": "Rad",
+                           "sensor": ["abi"], "channel": "C08"}
+
         self.msg0deg = SegmentGatherer(CONFIG_SINGLE)
         self.msg0deg_iodc = SegmentGatherer(CONFIG_DOUBLE)
         self.hrpt_pps = SegmentGatherer(CONFIG_NO_SEG)
         self.msg_ini = SegmentGatherer(CONFIG_INI)
+        self.goes_ini = SegmentGatherer(CONFIG_INI_NO_SEG)
 
     def test_init(self):
         self.assertTrue(self.msg0deg._config == CONFIG_SINGLE)
@@ -156,6 +171,15 @@ class TestSegmentGatherer(unittest.TestCase):
         fname_set = self.hrpt_pps._compose_filenames(
             'pps', slot_str,
             self.hrpt_pps._config['patterns']['pps']['critical_files'])
+        self.assertEqual(len(fname_set), 0)
+
+        # Tests using filesets with no segments, INI config
+        mda = self.mda_goes16.copy()
+        self.goes_ini._init_data(mda)
+        slot_str = str(mda["start_time"])
+        fname_set = self.goes_ini._compose_filenames(
+            'goes16', slot_str,
+            self.goes_ini._config['patterns']['goes16']['critical_files'])
         self.assertEqual(len(fname_set), 0)
 
     def test_set_logger(self):

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -133,7 +133,7 @@ class TestSegmentGatherer(unittest.TestCase):
         self.assertTrue("H-000-MSG3__-MSG3________-_________-PRO______-201611281100-__" in fname_set)
         self.assertTrue("H-000-MSG3__-MSG3________-_________-EPI______-201611281100-__" in fname_set)
         fname_set = self.msg0deg._compose_filenames('msg', slot_str, None)
-        self.assertTrue("H-000-MSG3__-MSG3________-_________-_________-201611281100-__" in fname_set)
+        self.assertEqual(len(fname_set), 0)
         # Check that MSG segments can be given as range, and the
         # result is same as with explicit segment names
         fname_set_range = self.msg0deg._compose_filenames(
@@ -145,18 +145,18 @@ class TestSegmentGatherer(unittest.TestCase):
         self.assertEqual(len(fname_set_range), len(fname_set_explicit))
         self.assertEqual(len(fname_set_range.difference(fname_set_explicit)), 0)
 
-        # Tests using to filesets with no segments
+        # Tests using filesets with no segments
         mda = self.mda_hrpt.copy()
         self.hrpt_pps._init_data(mda)
         slot_str = str(mda["start_time"])
         fname_set = self.hrpt_pps._compose_filenames(
             'hrpt', slot_str,
             self.hrpt_pps._config['patterns']['hrpt']['critical_files'])
-        self.assertEqual(len(fname_set), 1)
+        self.assertEqual(len(fname_set), 0)
         fname_set = self.hrpt_pps._compose_filenames(
             'pps', slot_str,
             self.hrpt_pps._config['patterns']['pps']['critical_files'])
-        self.assertEqual(len(fname_set), 1)
+        self.assertEqual(len(fname_set), 0)
 
     def test_set_logger(self):
         logger = logging.getLogger('foo')
@@ -200,6 +200,7 @@ class TestSegmentGatherer(unittest.TestCase):
         self.assertEqual(func(status, future, slot_str), SLOT_NOT_READY)
 
         status = {'foo': SLOT_NONCRITICAL_NOT_READY}
+        self.msg0deg.slots[slot_str] = {'foo': {'received_files': [0, 1]}}
         self.assertEqual(func(status, past, slot_str), SLOT_READY)
         self.assertEqual(func(status, future, slot_str),
                          SLOT_NONCRITICAL_NOT_READY)
@@ -309,11 +310,9 @@ class TestSegmentGatherer(unittest.TestCase):
             res = col.add_file(time_slot, key, mda, msg_data[key])
             self.assertTrue(res is None)
             self.assertEqual(len(col.slots[time_slot][key]['received_files']),
-                             1)
+                             0)
             meta = col.slots[time_slot]['metadata']
-            self.assertEqual(len(meta['collection'][key]['dataset']), 1)
-            self.assertTrue('uri' in meta['collection'][key]['dataset'][0])
-            self.assertTrue('uid' in meta['collection'][key]['dataset'][0])
+            self.assertEqual(len(meta['collection'][key]['dataset']), 0)
             i += 1
 
     def test_ini_to_dict(self):

--- a/pytroll_collectors/tests/test_trigger.py
+++ b/pytroll_collectors/tests/test_trigger.py
@@ -24,7 +24,10 @@
 """
 
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 from pytroll_collectors.trigger import PostTrollTrigger
 from datetime import datetime, timedelta
 import time


### PR DESCRIPTION
Segment gatherer added an filename with empty segment/channel to the list of "wanted files" if e.g. "critical files" were empty in an INI-based config. This PR fixes that, and additionally fixes unittests that failed due to earlier similar changes to YAML-based config.