### PR TITLE
Bugfix segment gatherer when files have no segments nor channels

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -163,9 +163,17 @@ class SegmentGatherer(object):
         meta = _copy_without_ignore_items(meta,
                                           ignored_keys=var_tags)
 
+        parser = self._parsers[key]
+
         for itm in itm_str.split(','):
             channel_name, segments = itm.split(':')
             if channel_name == '' and segments == '':
+                # If the filename pattern has no segments/channels,
+                # add the "plain" globified filename to the filename
+                # set
+                if ('channel_name' not in parser.fmt and
+                    'segment' not in parser.fmt):
+                    result.add(parser.globify(meta))
                 continue
             segments = segments.split('-')
             if len(segments) > 1:
@@ -178,7 +186,7 @@ class SegmentGatherer(object):
             meta['channel_name'] = channel_name
             for seg in segments:
                 meta['segment'] = seg
-                fname = self._parsers[key].globify(meta)
+                fname = parser.globify(meta)
 
                 result.add(fname)
 

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -167,11 +167,15 @@ class TestSegmentGatherer(unittest.TestCase):
         fname_set = self.hrpt_pps._compose_filenames(
             'hrpt', slot_str,
             self.hrpt_pps._config['patterns']['hrpt']['critical_files'])
-        self.assertEqual(len(fname_set), 0)
+        self.assertEqual(len(fname_set), 1)
+        self.assertTrue("hrpt_*_20180319_0955_28538.l1b" in fname_set)
         fname_set = self.hrpt_pps._compose_filenames(
             'pps', slot_str,
             self.hrpt_pps._config['patterns']['pps']['critical_files'])
-        self.assertEqual(len(fname_set), 0)
+        self.assertEqual(len(fname_set), 1)
+        self.assertTrue(
+            "S_NWC_CMA_*_28538_20180319T0955???Z_????????T???????Z.nc" in \
+            fname_set)
 
         # Tests using filesets with no segments, INI config
         mda = self.mda_goes16.copy()
@@ -334,9 +338,9 @@ class TestSegmentGatherer(unittest.TestCase):
             res = col.add_file(time_slot, key, mda, msg_data[key])
             self.assertTrue(res is None)
             self.assertEqual(len(col.slots[time_slot][key]['received_files']),
-                             0)
+                             1)
             meta = col.slots[time_slot]['metadata']
-            self.assertEqual(len(meta['collection'][key]['dataset']), 0)
+            self.assertEqual(len(meta['collection'][key]['dataset']), 1)
             i += 1
 
     def test_ini_to_dict(self):


### PR DESCRIPTION
An earlier PR by me introduced an bug that filename patterns without channels and segments were not added to expected files. This PR fixes that bug.