### PR TITLE
Make it possible to group segments for full minutes

### DIFF
--- a/bin/gatherer.py
+++ b/bin/gatherer.py
@@ -132,6 +132,11 @@ def arg_parse():
     parser.add_argument("-c", "--config-item",
                         help="config item to use (all by default). Can be specified multiply times",
                         action="append")
+    parser.add_argument("-p", "--publish-port",
+                        help="Port to publish the messages on. Default: automatic")
+    parser.add_argument("-n", "--nameservers",
+                        help=("Connect publisher to given nameservers: "
+                              "'localhost,123.456.789.0'. Default: localhost"))
     parser.add_argument("config", help="config file to be used")
 
     return parser.parse_args()
@@ -247,9 +252,20 @@ def main():
             LOGGER.error("No valid config item provided")
             return
 
+    if opts.publish_port:
+        publish_port = int(opts.publish_port)
+    else:
+        publish_port = 0
+
+    if opts.nameservers:
+        publisher_nameservers = opts.nameservers.split(',')
+    else:
+        publisher_nameservers = None
+
     decoder = get_metadata
 
-    PUB = publisher.NoisyPublisher("gatherer")
+    PUB = publisher.NoisyPublisher("gatherer", port=publish_port,
+                                   nameservers=publisher_nameservers)
 
     granule_triggers = setup(decoder)
 

--- a/bin/gatherer.py
+++ b/bin/gatherer.py
@@ -132,11 +132,12 @@ def arg_parse():
     parser.add_argument("-c", "--config-item",
                         help="config item to use (all by default). Can be specified multiply times",
                         action="append")
-    parser.add_argument("-p", "--publish-port",
+    parser.add_argument("-p", "--publish-port", default=0, type=int,
                         help="Port to publish the messages on. Default: automatic")
     parser.add_argument("-n", "--nameservers",
                         help=("Connect publisher to given nameservers: "
-                              "'localhost,123.456.789.0'. Default: localhost"))
+                              "'-n localhost -n 123.456.789.0'. Default: localhost"),
+                        action="append")
     parser.add_argument("config", help="config file to be used")
 
     return parser.parse_args()
@@ -252,15 +253,8 @@ def main():
             LOGGER.error("No valid config item provided")
             return
 
-    if opts.publish_port:
-        publish_port = int(opts.publish_port)
-    else:
-        publish_port = 0
-
-    if opts.nameservers:
-        publisher_nameservers = opts.nameservers.split(',')
-    else:
-        publisher_nameservers = None
+    publish_port = opts.publish_port
+    publisher_nameservers = opts.nameservers
 
     decoder = get_metadata
 

--- a/examples/segment_gatherer_himawari.ini_template
+++ b/examples/segment_gatherer_himawari.ini_template
@@ -22,7 +22,7 @@ variable_tags = start_minute
 
 # Group the data for every full 10-minute interval
 # For example in this case time of "201712081129" would go in slot
-# "2017-12-08T11:20:00" along with other files with minutes less than 30.
+# "2017-12-08T11:20:00" along with other files with minutes between 20 and 29.
 group_by_minutes = 10
 
 # We want the start time which is parsed from the filename so that the

--- a/examples/segment_gatherer_himawari.ini_template
+++ b/examples/segment_gatherer_himawari.ini_template
@@ -28,5 +28,5 @@ add_minutes = 10
 add_minutes_multiplier = start_ten_minutes
 
 # We want the start time which is parsed from the filename so that the
-time slots match the 10-minute periodicity
+# time slots match the 10-minute periodicity
 use_message_start_time = False

--- a/examples/segment_gatherer_himawari.ini_template
+++ b/examples/segment_gatherer_himawari.ini_template
@@ -1,0 +1,28 @@
+[himawari-8]
+#IMG_DK01IR4_201712081109_010
+pattern = IMG_{platform_name:4s}{channel_name:3s}_{start_time:%Y%m%d%H}{start_ten_minutes:1d}{start_minute:1d}_{segment:0>3s}
+critical_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B09:001-010,B10:001-010,B11:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
+wanted_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B06:001-010,B09:001-010,B10:001-010,B11:001-010,B12:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
+all_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B06:001-010,B09:001-010,B10:001-010,B11:001-010,B12:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
+
+# Topic to listen to
+topics = /listener/topic
+
+# Topic in the published message
+publish_topic = /publish/topic
+
+# Wait for 20 minutes for the missing files
+timeliness = 1200
+
+# Name of the scene start time in the filename pattern
+time_name = start_time
+
+# Start time varies within the scene
+variable_tags = start_minute
+
+# Adjust scene start time to match the data
+# The step is 10 minutes ...
+add_minutes = 10
+# ... multiply "add_minutes" by the value of "start_ten_minutes" field in the
+#     filename pattern
+add_minutes_multiplier = start_ten_minutes

--- a/examples/segment_gatherer_himawari.ini_template
+++ b/examples/segment_gatherer_himawari.ini_template
@@ -1,6 +1,6 @@
 [himawari-8]
 #IMG_DK01IR4_201712081109_010
-pattern = IMG_{platform_name:4s}{channel_name:3s}_{start_time:%Y%m%d%H}{start_ten_minutes:1d}{start_minute:1d}_{segment:0>3s}
+pattern = IMG_{platform_name:4s}{channel_name:3s}_{start_time:%Y%m%d%H%M}_{segment:0>3s}
 critical_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B09:001-010,B10:001-010,B11:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
 wanted_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B06:001-010,B09:001-010,B10:001-010,B11:001-010,B12:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
 all_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B06:001-010,B09:001-010,B10:001-010,B11:001-010,B12:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
@@ -21,6 +21,8 @@ time_name = start_time
 variable_tags = start_minute
 
 # Group the data for every full 10-minute interval
+# For example in this case time of "201712081129" would go in slot
+# "2017-12-08T11:20:00" along with other files with minutes less than 30.
 group_by_minutes = 10
 
 # We want the start time which is parsed from the filename so that the

--- a/examples/segment_gatherer_himawari.ini_template
+++ b/examples/segment_gatherer_himawari.ini_template
@@ -20,12 +20,8 @@ time_name = start_time
 # Start time varies within the scene
 variable_tags = start_minute
 
-# Adjust scene start time to match the data
-# The step is 10 minutes ...
-add_minutes = 10
-# ... multiply "add_minutes" by the value of "start_ten_minutes" field in the
-#     filename pattern
-add_minutes_multiplier = start_ten_minutes
+# Group the data for every full 10-minute interval
+group_by_minutes = 10
 
 # We want the start time which is parsed from the filename so that the
 # time slots match the 10-minute periodicity.  It is possible to give

--- a/examples/segment_gatherer_himawari.ini_template
+++ b/examples/segment_gatherer_himawari.ini_template
@@ -26,3 +26,7 @@ add_minutes = 10
 # ... multiply "add_minutes" by the value of "start_ten_minutes" field in the
 #     filename pattern
 add_minutes_multiplier = start_ten_minutes
+
+# We want the start time which is parsed from the filename so that the
+time slots match the 10-minute periodicity
+use_message_start_time = False

--- a/examples/segment_gatherer_himawari.ini_template
+++ b/examples/segment_gatherer_himawari.ini_template
@@ -17,9 +17,6 @@ timeliness = 1200
 # Name of the scene start time in the filename pattern
 time_name = start_time
 
-# Start time varies within the scene
-variable_tags = start_minute
-
 # Group the data for every full 10-minute interval
 # For example in this case time of "201712081129" would go in slot
 # "2017-12-08T11:20:00" along with other files with minutes between 20 and 29.

--- a/examples/segment_gatherer_himawari.ini_template
+++ b/examples/segment_gatherer_himawari.ini_template
@@ -28,5 +28,7 @@ add_minutes = 10
 add_minutes_multiplier = start_ten_minutes
 
 # We want the start time which is parsed from the filename so that the
-# time slots match the 10-minute periodicity
-use_message_start_time = False
+# time slots match the 10-minute periodicity.  It is possible to give
+# a space-separated list of keys that are kept from the filename
+# pattern and not replaced with message metadata
+keep_parsed_keys = start_time

--- a/pytroll_collectors/helper_functions.py
+++ b/pytroll_collectors/helper_functions.py
@@ -206,6 +206,6 @@ def read_yaml(fname):
     import yaml
 
     with open(fname, 'r') as fid:
-        data = yaml.load(fid)
+        data = yaml.load(fid, Loader=yaml.SafeLoader)
 
     return data

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -71,6 +71,11 @@ class SegmentGatherer(object):
                          key in self._patterns}
 
         self.time_name = config.get('time_name', 'start_time')
+        # Add `add_minutes * add_minutes_multiplier` to the start time
+        # If these values are strings, use those as filename pattern
+        # field names and get the numbers from the filename
+        self.add_minutes = config.get('add_minutes', 0)
+        self.add_minutes_multiplier = config.get('add_minutes_multiplier', 1)
 
         self.logger = logging.getLogger("segment_gatherer")
         self._loop = False
@@ -401,6 +406,7 @@ class SegmentGatherer(object):
 
         parser = self._parsers[key]
         mda = parser.parse(msg.data["uid"])
+        mda = self._add_minutes(mda)
 
         metadata = copy_metadata(mda, msg)
 
@@ -412,6 +418,18 @@ class SegmentGatherer(object):
 
         # Check if this file has been received already
         self.add_file(time_slot, key, mda, msg.data)
+
+    def _add_minutes(self, mda):
+        """Add minutes to the start_time."""
+        minutes = self.add_minutes
+        multiplier = self.add_minutes_multiplier
+        if isinstance(minutes, str):
+            minutes = mda.get(minutes, 0)
+        if instance(multiplier, str):
+            multiplier = mda.get(multiplier, 1)
+        mda[self.time_name] += dt.timedelta(minutes * multiplier)
+
+        return mda
 
     def add_file(self, time_slot, key, mda, msg_data):
         """Add file to the correct filelist."""
@@ -564,6 +582,26 @@ def ini_to_dict(fname, section):
             config.getint(section, "num_files_premature_publish")
     except (NoOptionError, ValueError):
         conf['num_files_premature_publish'] = -1
+
+    try:
+        conf['add_minutes'] = config.get(section, 'add_minutes')
+        try:
+            conf['add_minutes'] = float(conf['add_minutes'])
+        except ValueError:
+            pass
+    except NoOptionError:
+        pass
+
+    try:
+        conf['add_minutes_multiplier'] = config.get(section,
+                                                    'add_minutes_multiplier')
+        try:
+            conf['add_minutes_multiplier'] = \
+                float(conf['add_minutes_multiplier'])
+        except ValueError:
+            pass
+    except NoOptionError:
+        pass
 
     return conf
 

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -411,7 +411,7 @@ class SegmentGatherer(object):
         mda = self._add_minutes(mda)
 
         metadata = copy_metadata(mda, msg,
-                                 keep_parsed_keys=self.keep_parsed_keys)
+                                 keep_parsed_keys=self._keep_parsed_keys)
 
         time_slot = self._find_time_slot(metadata[self.time_name])
 

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -410,7 +410,7 @@ class SegmentGatherer(object):
 
         metadata = copy_metadata(mda, msg)
 
-        time_slot = self._find_time_slot(metadata["start_time"])
+        time_slot = self._find_time_slot(metadata[self.time_name])
 
         # Init metadata etc if this is the first file
         if time_slot not in self.slots:

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -425,7 +425,7 @@ class SegmentGatherer(object):
         multiplier = self.add_minutes_multiplier
         if isinstance(minutes, str):
             minutes = mda.get(minutes, 0)
-        if instance(multiplier, str):
+        if isinstance(multiplier, str):
             multiplier = mda.get(multiplier, 1)
         mda[self.time_name] += dt.timedelta(minutes * multiplier)
 

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -629,7 +629,7 @@ def copy_metadata(mda, msg, time_name=None):
     # Update with data given in the message
     for key in msg.data:
         # If time name is given, do not overwrite it
-        if key not in DO_NOT_COPY_KEYS or key != time_name:
+        if key not in DO_NOT_COPY_KEYS and key != time_name:
             metadata[key] = msg.data[key]
 
     return metadata

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -405,7 +405,7 @@ class SegmentGatherer(object):
 
         parser = self._parsers[key]
         mda = parser.parse(msg.data["uid"])
-        mda = self._floor_minutes(mda)
+        mda = self._floor_time(mda)
 
         metadata = copy_metadata(mda, msg,
                                  keep_parsed_keys=self._keep_parsed_keys)

--- a/pytroll_collectors/tests/data/segments.ini
+++ b/pytroll_collectors/tests/data/segments.ini
@@ -31,4 +31,4 @@ time_name = start_time
 variable_tags = start_minute
 add_minutes = 10
 add_minutes_multiplier = start_ten_minutes
-use_message_start_time = False
+keep_parsed_keys = start_time

--- a/pytroll_collectors/tests/data/segments.ini
+++ b/pytroll_collectors/tests/data/segments.ini
@@ -20,7 +20,7 @@ time_name = start_time
 variable_tags = end_time,end_frac_sec,creation_time
 
 [himawari-8]
-pattern = IMG_DK01{channel_name:3s}_{start_time:%Y%m%d%H}{start_ten_minutes:1d}{start_minute:1d}_{segment:0>3s}
+pattern = IMG_DK01{channel_name:3s}_{start_time:%Y%m%d%H%M}_{segment:0>3s}
 critical_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B09:001-010,B10:001-010,B11:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
 wanted_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B06:001-010,B09:001-010,B10:001-010,B11:001-010,B12:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
 all_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B06:001-010,B09:001-010,B10:001-010,B11:001-010,B12:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
@@ -29,6 +29,5 @@ publish_topic = /himawari/H8/segment
 timeliness = 1200
 time_name = start_time
 variable_tags = start_minute
-add_minutes = 10
-add_minutes_multiplier = start_ten_minutes
+group_by_minutes = 10
 keep_parsed_keys = start_time

--- a/pytroll_collectors/tests/data/segments.ini
+++ b/pytroll_collectors/tests/data/segments.ini
@@ -18,3 +18,17 @@ publish_topic = /pub/foo/bar
 timeliness = 1500
 time_name = start_time
 variable_tags = end_time,end_frac_sec,creation_time
+
+[himawari-8]
+pattern = IMG_DK01{channel_name:3s}_{start_time:%Y%m%d%H}{start_ten_minutes:1d}{start_minute:1d}_{segment:0>3s}
+critical_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B09:001-010,B10:001-010,B11:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
+wanted_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B06:001-010,B09:001-010,B10:001-010,B11:001-010,B12:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
+all_files = B01:001-010,B02:001-010,B04:001-010,B05:001-010,B06:001-010,B09:001-010,B10:001-010,B11:001-010,B12:001-010,B14:001-010,B16:001-010,IR1:001-010,IR2:001-010,IR3:001-010,IR4:001-010,VIS:001-010
+topics = /himawari/H8/L1
+publish_topic = /himawari/H8/segment
+timeliness = 1200
+time_name = start_time
+variable_tags = start_minute
+add_minutes = 10
+add_minutes_multiplier = start_ten_minutes
+use_message_start_time = False

--- a/pytroll_collectors/tests/data/segments.ini
+++ b/pytroll_collectors/tests/data/segments.ini
@@ -28,6 +28,5 @@ topics = /himawari/H8/L1
 publish_topic = /himawari/H8/segment
 timeliness = 1200
 time_name = start_time
-variable_tags = start_minute
 group_by_minutes = 10
 keep_parsed_keys = start_time

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -47,7 +47,8 @@ CONFIG_INI = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"), "msg")
 CONFIG_INI_NO_SEG = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"),
                                 "goes16")
 CONFIG_INI_HIMAWARI = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"),
-                                               "himawari-8")
+                                  "himawari-8")
+
 
 class TestSegmentGatherer(unittest.TestCase):
     """Tests for the segment gatherer."""

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -404,7 +404,7 @@ class TestSegmentGatherer(unittest.TestCase):
         self.assertEqual(res['c'], 3)
 
         # Keep 'a' from parsed metadata
-        res = copy_metadata(mda, msg, time_name='a')
+        res = copy_metadata(mda, msg, keep_parsed_keys=['a'])
         self.assertEqual(res['a'], 1)
         self.assertEqual(res['b'], 2)
         self.assertEqual(res['c'], 3)

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -386,6 +386,29 @@ class TestSegmentGatherer(unittest.TestCase):
         #    2 * 20 = 20
         self.assertEqual(mda2['start_time'].minute, 20)
 
+    def test_copy_metadata(self):
+        """Test combining metadata from a message and parsed from filename."""
+        from pytroll_collectors.segments import copy_metadata
+        try:
+            from unittest import mock
+        except ImportError:
+            import mock
+
+        mda = {'a': 1, 'b': 2}
+        msg = mock.MagicMock()
+        msg.data = {'a': 2, 'c': 3}
+
+        res = copy_metadata(mda, msg)
+        self.assertEqual(res['a'], 2)
+        self.assertEqual(res['b'], 2)
+        self.assertEqual(res['c'], 3)
+
+        # Keep 'a' from parsed metadata
+        res = copy_metadata(mda, msg, time_name='a')
+        self.assertEqual(res['a'], 1)
+        self.assertEqual(res['b'], 2)
+        self.assertEqual(res['c'], 3)
+
 
 def suite():
     """Test suite for test_trollduction."""

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -46,7 +46,8 @@ CONFIG_NO_SEG = read_yaml(os.path.join(THIS_DIR,
 CONFIG_INI = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"), "msg")
 CONFIG_INI_NO_SEG = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"),
                                 "goes16")
-
+CONFIG_INI_HIMAWARI = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"),
+                                               "himawari-8")
 
 class TestSegmentGatherer(unittest.TestCase):
     """Tests for the segment gatherer."""
@@ -82,6 +83,7 @@ class TestSegmentGatherer(unittest.TestCase):
         self.hrpt_pps = SegmentGatherer(CONFIG_NO_SEG)
         self.msg_ini = SegmentGatherer(CONFIG_INI)
         self.goes_ini = SegmentGatherer(CONFIG_INI_NO_SEG)
+        self.himawari_ini = SegmentGatherer(CONFIG_INI_HIMAWARI)
 
     def test_init(self):
         """Test init."""
@@ -372,6 +374,17 @@ class TestSegmentGatherer(unittest.TestCase):
         self.assertTrue('all_files' in config['patterns']['msg'])
         self.assertTrue('is_critical_set' in config['patterns']['msg'])
         self.assertTrue('variable_tags' in config['patterns']['msg'])
+
+    def test_add_minutes(self):
+        """Test that adding minutes work."""
+        parser = self.himawari_ini._parsers['himawari-8']
+        mda = parser.parse("IMG_DK01IR4_201712081129_010")
+        # The pattern doesn't collect minutes in the start_time variable
+        self.assertEqual(mda['start_time'].minute, 0)
+        mda2 = self.himawari_ini._add_minutes(mda.copy())
+        # multiplier * add_minutes = mda['start_ten_minutes'] * 10 =
+        #    2 * 20 = 20
+        self.assertEqual(mda2['start_time'].minute, 20)
 
 
 def suite():

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -375,16 +375,19 @@ class TestSegmentGatherer(unittest.TestCase):
         self.assertTrue('is_critical_set' in config['patterns']['msg'])
         self.assertTrue('variable_tags' in config['patterns']['msg'])
 
-    def test_add_minutes(self):
-        """Test that adding minutes work."""
+    def test_floor_time(self):
+        """Test that flooring the time to set minutes work."""
         parser = self.himawari_ini._parsers['himawari-8']
         mda = parser.parse("IMG_DK01IR4_201712081129_010")
-        # The pattern doesn't collect minutes in the start_time variable
-        self.assertEqual(mda['start_time'].minute, 0)
-        mda2 = self.himawari_ini._add_minutes(mda.copy())
-        # multiplier * add_minutes = mda['start_ten_minutes'] * 10 =
-        #    2 * 20 = 20
+        self.assertEqual(mda['start_time'].minute, 29)
+        mda2 = self.himawari_ini._floor_time(mda.copy())
         self.assertEqual(mda2['start_time'].minute, 20)
+        self.himawari_ini._group_by_minutes = 15
+        mda2 = self.himawari_ini._floor_time(mda.copy())
+        self.assertEqual(mda2['start_time'].minute, 15)
+        self.himawari_ini._group_by_minutes = 2
+        mda2 = self.himawari_ini._floor_time(mda.copy())
+        self.assertEqual(mda2['start_time'].minute, 28)
 
     def test_copy_metadata(self):
         """Test combining metadata from a message and parsed from filename."""


### PR DESCRIPTION
This PR makes it possible to group segments for given full minutes.

The feature makes it possible to collect e.g. Himawari-8 segments that otherwise would require 6 separate collectors (one for each 10-minute slot), and then would have incorrect time attached for slots not starting at full hour. To configure (see full example in `examples/segment_gatherer.ini_template`, `[himawari-8]` section):

```ini
pattern = IMG_{platform_name:4s}{channel_name:3s}_{start_time:%Y%m%d%H%M}_{segment:0>3s}
...
group_by_minutes = 10
keep_parsed_keys = start_time
```

This means that the segments are group for every full 10 minute period. This period can be anything from `1` (group for every full minute) onwards. Values equal or greater than `60` will group the data to full hours.

The last option means that the `start_time` parsed from the filename is not overwritten by the time given in the incoming message. Any other tags in the pattern can be given in same way.