### PR TITLE
Fix bug when naming publisher with config_item

### DIFF
--- a/bin/gatherer.py
+++ b/bin/gatherer.py
@@ -252,13 +252,16 @@ def main():
         if len(CONFIG.sections()) == 0:
             LOGGER.error("No valid config item provided")
             return
+        publisher_name = "gatherer_" + "_".join(opts.config_item)
+    else:
+        publisher_name = "gatherer"
 
     publish_port = opts.publish_port
     publisher_nameservers = opts.nameservers
 
     decoder = get_metadata
 
-    PUB = publisher.NoisyPublisher("gatherer_" + opts.config_item, port=publish_port,
+    PUB = publisher.NoisyPublisher(publisher_name, port=publish_port,
                                    nameservers=publisher_nameservers)
 
     granule_triggers = setup(decoder)


### PR DESCRIPTION
The gatherer had a problem with the config_items type when using it the the name of the publisher: 

Traceback (most recent call last):
  File "/opt/conda/bin/gatherer.py", line 291, in <module>
    main()
  File "/opt/conda/bin/gatherer.py", line 261, in main
    PUB = publisher.NoisyPublisher("gatherer_" + opts.config_item, port=publish_port,
TypeError: can only concatenate str (not "list") to str

I changed how the name is created.