### PR TITLE
Floor minutes only if configured

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -72,7 +72,7 @@ class SegmentGatherer(object):
 
         self.time_name = config.get('time_name', 'start_time')
         # Floor the scene start time to the given full minutes
-        self._group_by_minutes = config.get('group_by_minutes', 1)
+        self._group_by_minutes = config.get('group_by_minutes', None)
 
         self._keep_parsed_keys = config.get('keep_parsed_keys', [])
 
@@ -405,7 +405,8 @@ class SegmentGatherer(object):
 
         parser = self._parsers[key]
         mda = parser.parse(msg.data["uid"])
-        mda = self._floor_time(mda)
+        if self._group_by_minutes is not None:
+            mda = self._floor_time(mda)
 
         metadata = copy_metadata(mda, msg,
                                  keep_parsed_keys=self._keep_parsed_keys)

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -432,8 +432,7 @@ class SegmentGatherer(object):
 
         parser = self._parsers[key]
         mda = parser.parse(msg.data["uid"])
-        if self._group_by_minutes is not None:
-            mda = self._floor_time(mda)
+        mda = self._floor_time(mda)
 
         metadata = copy_metadata(mda, msg,
                                  keep_parsed_keys=self._keep_parsed_keys)
@@ -462,6 +461,8 @@ class SegmentGatherer(object):
 
     def _floor_time(self, mda):
         """Floor time to full minutes."""
+        if self._group_by_minutes is None:
+            return mda
         start_time = mda[self.time_name]
         mins = start_time.minute
         fl_mins = int(mins / self._group_by_minutes) * self._group_by_minutes

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -408,9 +408,22 @@ class TestSegmentGatherer(unittest.TestCase):
         self.himawari_ini._group_by_minutes = 2
         mda2 = self.himawari_ini._floor_time(mda.copy())
         self.assertEqual(mda2['start_time'].minute, 28)
-        self.himawari_ini._group_by_minutes = None
+        # Add seconds
+        mod_mda = mda.copy()
+        start_time = mda['start_time']
+        mod_mda['start_time'] = dt.datetime(start_time.year, start_time.month,
+                                            start_time.day, start_time.hour,
+                                            start_time.minute, 42)
+        # The seconds should also be zero'd
         mda2 = self.himawari_ini._floor_time(mda.copy())
-        self.assertEqual(mda2['start_time'].minute, mda['start_time'].minute)
+        self.assertEqual(mda2['start_time'].minute, 28)
+        self.assertEqual(mda2['start_time'].second, 0)
+
+        # Test that nothing is changed when groub_by_minutes has not
+        # been configured
+        self.himawari_ini._group_by_minutes = None
+        mda2 = self.himawari_ini._floor_time(mod_mda.copy())
+        self.assertEqual(mda2['start_time'], mod_mda['start_time'])
 
     def test_copy_metadata(self):
         """Test combining metadata from a message and parsed from filename."""

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -408,6 +408,9 @@ class TestSegmentGatherer(unittest.TestCase):
         self.himawari_ini._group_by_minutes = 2
         mda2 = self.himawari_ini._floor_time(mda.copy())
         self.assertEqual(mda2['start_time'].minute, 28)
+        self.himawari_ini._group_by_minutes = None
+        mda2 = self.himawari_ini._floor_time(mda.copy())
+        self.assertEqual(mda2['start_time'].minute, mda['start_time'].minute)
 
     def test_copy_metadata(self):
         """Test combining metadata from a message and parsed from filename."""


### PR DESCRIPTION
This PR fixes a bug in segment gatherer where metadata `start_time` minutes were set to zero even if nothing was configured. Now they need to be explicitly set.