### PR TITLE
Fix times from posttroll messages when file duration is needed

### DIFF
--- a/bin/gatherer.py
+++ b/bin/gatherer.py
@@ -47,7 +47,6 @@ LOGGER = logging.getLogger(__name__)
 CONFIG = RawConfigParser()
 PUB = None
 
-trigger.LOG.setLevel(logging.DEBUG)
 
 def get_metadata(fname):
     """Parse metadata from the file."""
@@ -266,17 +265,15 @@ def main():
     publish_port = opts.publish_port
     publisher_nameservers = opts.nameservers
 
+    decoder = get_metadata
 
     PUB = publisher.NoisyPublisher(publisher_name, port=publish_port,
                                    nameservers=publisher_nameservers)
 
-    LOGGER.debug("Setup trigger")
-    granule_triggers = setup(get_metadata)
+    granule_triggers = setup(decoder)
 
-    LOGGER.debug("Start piublisher")
     PUB.start()
 
-    LOGGER.debug("Start granula trigger")
     for granule_trigger in granule_triggers:
         granule_trigger.start()
     try:

--- a/bin/gatherer.py
+++ b/bin/gatherer.py
@@ -47,7 +47,7 @@ LOGGER = logging.getLogger(__name__)
 CONFIG = RawConfigParser()
 PUB = None
 
-trigger.LOGGER.setLevel(logging.DEBUG)
+trigger.LOG.setLevel(logging.DEBUG)
 
 def get_metadata(fname):
     """Parse metadata from the file."""

--- a/bin/gatherer.py
+++ b/bin/gatherer.py
@@ -204,7 +204,7 @@ def setup(decoder):
                 collectors, terminator,
                 CONFIG.get(section, 'service').split(','),
                 CONFIG.get(section, 'topics').split(','),
-                duration,
+                duration=duration,
                 publish_topic=publish_topic, nameserver=nameserver,
                 publish_message_after_each_reception=publish_message_after_each_reception)
         granule_triggers.append(granule_trigger)

--- a/bin/gatherer.py
+++ b/bin/gatherer.py
@@ -197,7 +197,7 @@ def setup(decoder):
         else:
             LOGGER.debug("Using posttroll for %s", section)
             try:
-                duration = timedelta(seconds=CONFIG.getfloat(section, "duration"))
+                duration = CONFIG.getfloat(section, "duration")
             except NoOptionError:
                 duration = None
 

--- a/bin/gatherer.py
+++ b/bin/gatherer.py
@@ -282,6 +282,8 @@ def main():
         LOGGER.critical('Something went wrong!')
     except OSError:
         LOGGER.critical('Something went wrong!')
+    except BaseException:
+        LOGGER.exception('Something went wrong!')
     finally:
         LOGGER.warning('Ending publication the gathering of granules...')
         for granule_trigger in granule_triggers:

--- a/pytroll_collectors/tests/test_trigger.py
+++ b/pytroll_collectors/tests/test_trigger.py
@@ -69,6 +69,16 @@ class TestPostTrollTrigger(unittest.TestCase):
         ptt.stop()
         self.assertTrue(collector.timeout is None)
 
+    def test_duration(self):
+        """Test duration"""
+        from pytroll_collectors.trigger import PostTrollTrigger
+        ptt = PostTrollTrigger(None, None, None, None, duration=60)
+
+        msg_data = ptt.decode_message(FakeMessage({"a": "a", 'start_time': datetime(2020, 1, 21, 11, 27)}))
+
+        self.assertIn("end_time", msg_data)
+        self.assertEqual(msg_data["end_time"], datetime(2020, 1, 21, 11, 28))
+
 
 def suite():
     """Test suite for test_trigger."""

--- a/pytroll_collectors/trigger.py
+++ b/pytroll_collectors/trigger.py
@@ -58,7 +58,6 @@ def fix_start_end_time(mda):
         mda["end_time"] = datetime.combine(mda["end_date"].date(),
                                            mda["end_time"].time())
         del mda["end_date"]
-
     while mda["start_time"] > mda["end_time"]:
         mda["end_time"] += timedelta(days=1)
 
@@ -423,7 +422,12 @@ class PostTrollTrigger(FileTrigger):
     @staticmethod
     def decode_message(message):
         """Return the message data."""
-        return fix_start_end_time(message.data)
+        LOG.info("Decode message {}".format(message))
+        try:
+            mgs_data = fix_start_end_time(message.data)
+        except KeyError:
+            LOG.exception("Key error")
+        return mgs_data
 
     def stop(self):
         """Stop the posttroll trigger."""

--- a/pytroll_collectors/trigger.py
+++ b/pytroll_collectors/trigger.py
@@ -404,10 +404,11 @@ class AbstractMessageProcessor(Thread):
 class PostTrollTrigger(FileTrigger):
     """Get posttroll messages."""
 
-    def __init__(self, collectors, terminator, services, topics,
+    def __init__(self, collectors, terminator, services, topics, duration=None,
                  publish_topic=None, nameserver="localhost",
                  publish_message_after_each_reception=False):
         """Init the posttroll trigger."""
+        self.duration = duration
         self.msgproc = AbstractMessageProcessor(services, topics, nameserver=nameserver)
         self.msgproc.process = self.add_file
         FileTrigger.__init__(self, collectors, terminator, self.decode_message,
@@ -422,12 +423,15 @@ class PostTrollTrigger(FileTrigger):
     @staticmethod
     def decode_message(message):
         """Return the message data."""
-        LOG.info("Decode message {}".format(message))
+        if self.duration:
+            message.data["duration"] = duration
+        LOG.debug("Decode message {}".format(message))
         try:
             mgs_data = fix_start_end_time(message.data)
+            return mgs_data
         except KeyError:
             LOG.exception("Key error")
-        return mgs_data
+
 
     def stop(self):
         """Stop the posttroll trigger."""

--- a/pytroll_collectors/trigger.py
+++ b/pytroll_collectors/trigger.py
@@ -58,6 +58,7 @@ def fix_start_end_time(mda):
         mda["end_time"] = datetime.combine(mda["end_date"].date(),
                                            mda["end_time"].time())
         del mda["end_date"]
+
     while mda["start_time"] > mda["end_time"]:
         mda["end_time"] += timedelta(days=1)
 
@@ -420,7 +421,6 @@ class PostTrollTrigger(FileTrigger):
         FileTrigger.start(self)
         self.msgproc.start()
 
-    #@staticmethod
     def decode_message(self, message):
         """Return the message data."""
         if self.duration:

--- a/pytroll_collectors/trigger.py
+++ b/pytroll_collectors/trigger.py
@@ -423,15 +423,18 @@ class PostTrollTrigger(FileTrigger):
 
     def decode_message(self, message):
         """Return the message data."""
+
+        # Include file duration in message data
         if self.duration:
             message.data["duration"] = self.duration
-        LOG.debug("Decode message {}".format(message))
+
+        # Fix start and end time
         try:
             mgs_data = fix_start_end_time(message.data)
-            return mgs_data
         except KeyError:
-            LOG.exception("Key error")
-
+            LOG.exception("Something went wrong!")
+        else:
+            return mgs_data
 
     def stop(self):
         """Stop the posttroll trigger."""

--- a/pytroll_collectors/trigger.py
+++ b/pytroll_collectors/trigger.py
@@ -420,11 +420,11 @@ class PostTrollTrigger(FileTrigger):
         FileTrigger.start(self)
         self.msgproc.start()
 
-    @staticmethod
-    def decode_message(message):
+    #@staticmethod
+    def decode_message(self, message):
         """Return the message data."""
         if self.duration:
-            message.data["duration"] = duration
+            message.data["duration"] = self.duration
         LOG.debug("Decode message {}".format(message))
         try:
             mgs_data = fix_start_end_time(message.data)


### PR DESCRIPTION
This PR fixes an error in the decode_message method from the PosttrollTrigger, that was introduced in commit [f30d256](https://github.com/pytroll/pytroll-collectors/commit/f30d2567e1e90d4b13b45ffb9e2afe8830d44dfc)

```Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.6/dist-packages/pytroll_collectors/trigger.py", line 395, in run
    self.process(msg)
  File "/usr/local/lib/python3.6/dist-packages/pytroll_collectors/trigger.py", line 111, in add_file
    self._do(pathname)
  File "/usr/local/lib/python3.6/dist-packages/pytroll_collectors/trigger.py", line 105, in _do
    mda = self.decoder(pathname)
  File "/usr/local/lib/python3.6/dist-packages/pytroll_collectors/trigger.py", line 426, in decode_message
    return fix_start_end_time(message.data)
  File "/usr/local/lib/python3.6/dist-packages/pytroll_collectors/trigger.py", line 62, in fix_start_end_time
    while mda["start_time"] > mda["end_time"]:
KeyError: 'end_time'```

Noaa-19 data only includes start_time, and end_time is calculated using 'duration' from the gatherer config. The duration parameter will be parsed to the decode_message with these changes.