### PR TITLE
Add a way to populate segment gatherer with pre-existing files

### DIFF
--- a/examples/segment_gatherer_msg.yaml_template
+++ b/examples/segment_gatherer_msg.yaml_template
@@ -38,3 +38,7 @@ posttroll:
   # List of addresses for incoming messages. Default: [] (use multicast)
   # format: 123.456.78.9:12345
   # addresses: null
+
+# When the first message arrives after start-up, check if there are matching
+#   files available for the same slot.  Default: false
+# check_existing_files_after_start = true

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -518,6 +518,7 @@ class TestSegmentGatherer(unittest.TestCase):
         self.assertTrue('time_tolerance' in config)
         self.assertTrue('timeliness' in config)
         self.assertTrue('time_name' in config)
+        self.assertTrue('check_existing_files_after_start' in config)
 
         self.assertTrue('topics' in config['posttroll'])
         self.assertTrue('nameservers' in config['posttroll'])

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -576,6 +576,7 @@ class TestSegmentGatherer(unittest.TestCase):
         self.msg0deg._create_slot(message)
         slot_str = str(mda["start_time"])
         slot = self.msg0deg.slots[slot_str]
+        self.msg0deg._config['check_existing_files_after_start'] = True
 
         self.msg0deg.check_and_add_existing_files(slot, message)
         assert call(logging.DEBUG) in logging.disable.mock_calls

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -27,7 +27,7 @@ import logging
 import os
 import os.path
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 import pytest
 
@@ -49,6 +49,7 @@ CONFIG_INI_NO_SEG = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"),
                                 "goes16")
 CONFIG_INI_HIMAWARI = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"),
                                   "himawari-8")
+LOGGING_ERROR = logging.ERROR
 
 
 class FakeMessage:
@@ -104,27 +105,6 @@ class TestSegmentGatherer(unittest.TestCase):
         self.hrpt_pps = SegmentGatherer(CONFIG_NO_SEG)
         self.msg_ini = SegmentGatherer(CONFIG_INI)
         self.goes_ini = SegmentGatherer(CONFIG_INI_NO_SEG)
-
-    @patch("pytroll_collectors.segments.glob")
-    def test_check_and_add_existing_files(self, glob):
-        """Test that existing matching files are added to the slot."""
-        existing_files = [
-            "/home/lahtinep/data/satellite/geo/msg/H-000-MSG3__-MSG3________-VIS006___-000007___-201611281100-__",
-            "/home/lahtinep/data/satellite/geo/msg/H-000-MSG3__-MSG3________-VIS006___-000008___-201611281100-__",
-            # A file that should not match
-            "/home/lahtinep/data/satellite/geo/msg/H-000-MSG4__-MSG4________-VIS006___-000008___-201611281100-__"]
-        glob.glob.return_value = existing_files
-        mda = self.mda_msg0deg.copy()
-        fake_message = FakeMessage(mda)
-        message = Message(fake_message, self.msg0deg._patterns['msg'])
-        self.msg0deg._create_slot(message)
-        slot_str = str(mda["start_time"])
-        slot = self.msg0deg.slots[slot_str]
-
-        self.msg0deg.check_and_add_existing_files(slot, message)
-        for fname in existing_files[:-1]:
-            assert os.path.basename(fname) in slot._info['msg']['received_files']
-        assert os.path.basename(existing_files[-1]) not in slot._info['msg']['received_files']
 
     def test_init(self):
         """Test init."""
@@ -579,6 +559,50 @@ class TestSegmentGatherer(unittest.TestCase):
         col = self.msg0deg_iodc
         publish_service_name = col._generate_publish_service_name()
         self.assertEqual(publish_service_name, "segment_gatherer_iodc_msg")
+
+    @patch("pytroll_collectors.segments.logging")
+    @patch("pytroll_collectors.segments.glob")
+    def test_check_and_add_existing_files(self, glob, logging):
+        """Test that existing matching files are added to the slot."""
+        existing_files = [
+            "/home/lahtinep/data/satellite/geo/msg/H-000-MSG3__-MSG3________-VIS006___-000007___-201611281100-__",
+            "/home/lahtinep/data/satellite/geo/msg/H-000-MSG3__-MSG3________-VIS006___-000008___-201611281100-__",
+            # A file that should not match
+            "/home/lahtinep/data/satellite/geo/msg/H-000-MSG4__-MSG4________-VIS006___-000008___-201611281100-__"]
+        glob.glob.return_value = existing_files
+        mda = self.mda_msg0deg.copy()
+        fake_message = FakeMessage(mda)
+        message = Message(fake_message, self.msg0deg._patterns['msg'])
+        self.msg0deg._create_slot(message)
+        slot_str = str(mda["start_time"])
+        slot = self.msg0deg.slots[slot_str]
+
+        self.msg0deg.check_and_add_existing_files(slot, message)
+        assert call(logging.DEBUG) in logging.disable.mock_calls
+        assert call(logging.NOTSET) in logging.disable.mock_calls
+        assert logging.disable.call_count == 2
+        for fname in existing_files[:-1]:
+            assert os.path.basename(fname) in slot._info['msg']['received_files']
+        assert os.path.basename(existing_files[-1]) not in slot._info['msg']['received_files']
+
+        # For the next message(s) the existing files should not be handled
+        existing_files = [
+            "/home/lahtinep/data/satellite/geo/msg/H-000-MSG3__-MSG3________-VIS006___-000005___-201611281100-__",
+            "/home/lahtinep/data/satellite/geo/msg/H-000-MSG3__-MSG3________-VIS006___-000006___-201611281100-__"]
+        glob.glob.return_value = existing_files
+        self.msg0deg.check_and_add_existing_files(slot, message)
+        for fname in existing_files[:-1]:
+            assert os.path.basename(fname) not in slot._info['msg']['received_files']
+        assert logging.disable.call_count == 2
+
+        # Messages with other types than 'file' should be ignored
+        message.type = "collection"
+        self.msg0deg._is_first_message_after_start = True
+        with self._caplog.at_level(LOGGING_ERROR):
+            self.msg0deg.check_and_add_existing_files(slot, message)
+            logs = [rec.message for rec in self._caplog.records]
+            assert "Only 'file' messages are supported." in logs
+        assert logging.disable.call_count == 2
 
 
 viirs_message = (


### PR DESCRIPTION
This PR adds a config option that makes it possible to populate the segment gatherer with pre-existing files. The check is triggered only for the first received message after `segment_gatherer.py` is started. Only `"file"` messages and local filesystem are supported.

As use case, consider the segmented MSG SEVIRI data from Eumetcast. If a restart is required due to configuration change or upgrade, currently the restart needs to be done either during the short gap between two timeslots, re-send the messages from new files, or potentially lose all files that arrived before the restart, or even the full set if prologue or epilogue files are missed.

With this PR, the first incoming message triggers (if `check_existing_files_after_start` is set to `true` in config) a check for all the files in the same directory where the `'uri'` in the message points to. The matching files will be added to the newly created slot.