### PR TITLE
Remove 'six' as requirement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pytest pytest-cov trollsift six netifaces watchdog posttroll pyyaml pyinotify pyresample pytroll-schedule
+          pip install -U pytest pytest-cov trollsift netifaces watchdog posttroll pyyaml pyinotify pyresample pytroll-schedule
       - name: Install pytroll-collectors
         run: |
           pip install --no-deps -e .

--- a/bin/cat.py
+++ b/bin/cat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014, 2015 Martin Raspaud
+# Copyright (c) 2014 - 2021 Pytroll developers
 #
 # Author(s):
 #
@@ -26,7 +26,7 @@
 import argparse
 import logging
 import logging.config
-from six.moves.configparser import RawConfigParser, NoOptionError
+from configparser import RawConfigParser, NoOptionError
 from subprocess import Popen, PIPE
 import threading
 import os

--- a/bin/catter.py
+++ b/bin/catter.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2014, 2016 Martin Raspaud
-
+#
+# Copyright (c) 2014 - 2021 Pytroll developers
+#
 # Author(s):
-
+#
 #   Martin Raspaud <martin.raspaud@smhi.se>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -32,7 +32,7 @@ from posttroll.subscriber import Subscribe
 from posttroll.publisher import Publish
 from posttroll.message import Message
 from trollsift import compose
-from six.moves.configparser import RawConfigParser, NoOptionError
+from configparser import RawConfigParser, NoOptionError
 
 logger = logging.getLogger(__name__)
 

--- a/bin/geographic_gatherer.py
+++ b/bin/geographic_gatherer.py
@@ -29,7 +29,7 @@ import logging.handlers
 import os
 import os.path
 
-from six.moves.configparser import RawConfigParser
+from configparser import RawConfigParser
 
 from pytroll_collectors.geographic_gatherer import GeographicGatherer
 

--- a/bin/scisys_receiver.py
+++ b/bin/scisys_receiver.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012, 2013, 2014, 2017, 2020 Pytroll
+# Copyright (c) 2012 - 2021 Pytroll developers
 #
 # Author(s):
 #

--- a/bin/segment_gatherer.py
+++ b/bin/segment_gatherer.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2015, 2016 Panu Lahtinen
-
+#
+# Copyright (c) 2015 - 2021 Pytroll developers
+#
 # Author(s): Panu Lahtinen
-
+#
 #   Panu Lahtinen <panu.lahtinen@fmi.fi>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Segment gatherer."""

--- a/bin/trollstalker.py
+++ b/bin/trollstalker.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2013, 2014, 2015
-
+#
+# Copyright (c) 2013 - 2021 Pytroll developers
+#
 # Author(s):
-
+#
 #   Joonas Karjalainen <joonas.karjalainen@fmi.fi>
 #   Panu Lahtinen <panu.lahtinen@fmi.fi>
 #   Martin Raspaud <martin.raspaud@smhi.se>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -30,7 +30,7 @@ from pyinotify import WatchManager, ThreadedNotifier, ProcessEvent
 import pyinotify
 import sys
 import time
-from six.moves.configparser import RawConfigParser
+from configparser import RawConfigParser
 import logging
 import logging.config
 import os

--- a/bin/trollstalker2.py
+++ b/bin/trollstalker2.py
@@ -41,19 +41,12 @@ from pytroll_collectors.trigger import AbstractWatchDogProcessor
 
 logger = logging.getLogger(__name__)
 
-try:
-    # Python 2
-    str_or_unicode = (str, unicode)
-except NameError:
-    # Pyton 3
-    str_or_unicode = (str, bytes)
-
 
 class FilePublisher(AbstractWatchDogProcessor):
 
     def __init__(self, config):
         self.config = config.copy()
-        if isinstance(config["filepattern"], str_or_unicode):
+        if isinstance(config["filepattern"], (str, bytes)):
             self.config["filepattern"] = [self.config["filepattern"]]
 
         self.parsers = [Parser(filepattern)

--- a/bin/trollstalker2.py
+++ b/bin/trollstalker2.py
@@ -1,25 +1,25 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2013 - 2019 PyTroll Community
-
+#
+# Copyright (c) 2013 - 2021 Pytroll developers
+#
 # Author(s):
-
+#
 #   Joonas Karjalainen <joonas.karjalainen@fmi.fi>
 #   Panu Lahtinen <panu.lahtinen@fmi.fi>
 #   Martin Raspaud <martin.raspaud@smhi.se>
 #   Adam Dybbroe <adam.dybbroe@smhi.se
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -29,7 +29,7 @@
 import argparse
 import sys
 import time
-from six.moves.configparser import RawConfigParser
+from configparser import RawConfigParser
 import logging
 import logging.config
 import os.path

--- a/bin/zipcollector_runner.py
+++ b/bin/zipcollector_runner.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2017 Adam.Dybbroe
-
+#
+# Copyright (c) 2017 - 2021 Pytroll developers
+#
 # Author(s):
-
+#
 #   Adam.Dybbroe <adam.dybbroe@smhi.se>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -35,7 +35,7 @@ import tarfile
 from datetime import timedelta
 
 import yaml
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 import posttroll.subscriber
 from posttroll.publisher import Publish

--- a/pytroll_collectors/__init__.py
+++ b/pytroll_collectors/__init__.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2014 Martin Raspaud
-
+#
+# Copyright (c) 2014 - 2021 Pytroll developers
+#
 # Author(s):
-
+#
 #   Martin Raspaud <martin.raspaud@smhi.se>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/pytroll_collectors/file_notifiers.py
+++ b/pytroll_collectors/file_notifiers.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2014 Martin Raspaud
-
+#
+# Copyright (c) 2014 - 2021 Pytroll developers
+#
 # Author(s):
-
+#
 #   Martin Raspaud <martin.raspaud@smhi.se>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/pytroll_collectors/geographic_gatherer.py
+++ b/pytroll_collectors/geographic_gatherer.py
@@ -28,7 +28,7 @@ import logging
 import time
 import datetime as dt
 
-from six.moves.configparser import NoOptionError
+from configparser import NoOptionError
 from posttroll import publisher
 # Workaround for unit tests that don't need Satpy + Pyresample
 try:

--- a/pytroll_collectors/helper_functions.py
+++ b/pytroll_collectors/helper_functions.py
@@ -110,12 +110,7 @@ def align_time(input_val, steps=None,
     offset = offset or dt.timedelta(minutes=0)
     steps = steps or dt.timedelta(minutes=5)
 
-    try:
-        stepss = steps.total_seconds()
-    # Python 2.6 compatibility hack
-    except AttributeError:
-        stepss = steps.days * 86400. + \
-            steps.seconds + steps.microseconds * 1e-6
+    stepss = steps.total_seconds()
     val = input_val - offset
     vals = (val - val.min).seconds
     result = val - dt.timedelta(seconds=(vals - (vals // stepss) * stepss))

--- a/pytroll_collectors/helper_functions.py
+++ b/pytroll_collectors/helper_functions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014-2018
+# Copyright (c) 2014 - 2021 Pytroll developers
 #
 # Author(s):
 #
@@ -28,7 +28,7 @@ import os
 import datetime as dt
 import re
 import logging
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 import netifaces
 import socket
 

--- a/pytroll_collectors/scisys.py
+++ b/pytroll_collectors/scisys.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2020 Pytroll Developers
+# Copyright (c) 2012 - 2021 Pytroll developers
 #
 # Author(s):
 #
@@ -42,7 +42,7 @@ import socket
 import xml.etree.ElementTree as etree
 from datetime import datetime, timedelta
 from time import sleep
-from six.moves.urllib.parse import SplitResult, urlsplit, urlunsplit
+from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 from posttroll.message import Message
 from posttroll.publisher import Publish

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2015 - 2021 Pytroll developers 
+# Copyright (c) 2015 - 2021 Pytroll developers
 #
 # Author(s): Panu Lahtinen
 #

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2015, 2016 Panu Lahtinen
-
+#
+# Copyright (c) 2015 - 2021 Pytroll developers 
+#
 # Author(s): Panu Lahtinen
-
+#
 #   Panu Lahtinen <panu.lahtinen@fmi.fi>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -46,8 +46,8 @@ import os
 import trollsift
 from posttroll import message as pmessage, publisher
 from posttroll.listener import ListenerContainer
-from six.moves.queue import Empty
-from six.moves.urllib.parse import urlparse
+from queue import Empty
+from urllib.parse import urlparse
 
 logger = logging.getLogger("segment_gatherer")
 
@@ -844,7 +844,7 @@ def _copy_without_ignore_items(the_dict, ignored_keys='ignore'):
 
 def ini_to_dict(fname, section):
     """Convert *section* of .ini *config* to dictionary."""
-    from six.moves.configparser import RawConfigParser, NoOptionError
+    from configparser import RawConfigParser, NoOptionError
 
     config = RawConfigParser()
     config.read(fname)

--- a/pytroll_collectors/tests/test_helper_functions.py
+++ b/pytroll_collectors/tests/test_helper_functions.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2015 Adam.Dybbroe
-
+#
+# Copyright (c) 2015 - 2021 Pytroll developers
+#
 # Author(s):
-
+#
 #   Adam.Dybbroe <a000680@c14526.ad.smhi.se>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/pytroll_collectors/tests/test_region_collector.py
+++ b/pytroll_collectors/tests/test_region_collector.py
@@ -1,3 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2012 - 2021 Pytroll developers
+#
+# Author(s):
+#
+#   Martin Raspaud <martin.raspaud@smhi.se>
+#   Panu Lahtinen <panu.lahtinen@fmi.fi>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 """Test region collector functionality."""
 
 import logging

--- a/pytroll_collectors/tests/test_scisys.py
+++ b/pytroll_collectors/tests/test_scisys.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2013, 2014 Martin Raspaud
-
+#
+# Copyright (c) 2013 - 2021 Pytroll developers
+#
 # Author(s):
-
+#
 #   Martin Raspaud <martin.raspaud@smhi.se>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2018 PyTroll team
-
+#
+# Copyright (c) 2018 - 2021 Pytroll developers
+#
 # Author(s):
-
-#   panu.lahtinen@fmi.fi
-
+#
+#   Panu Lahtinen <panu.lahtinen@fmi.fi>
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/pytroll_collectors/triggers/__init__.py
+++ b/pytroll_collectors/triggers/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014 - 2021, Pytroll developers
+# Copyright (c) 2014 - 2021 Pytroll developers
 #
 # Author(s):
 #

--- a/pytroll_collectors/triggers/_base.py
+++ b/pytroll_collectors/triggers/_base.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012, 2014, 2015, 2019 Martin Raspaud
+# Copyright (c) 2012 - 2021 Pytroll developers
 #
 # Author(s):
 #
@@ -28,7 +28,7 @@ from datetime import datetime, timedelta
 import logging
 from threading import Thread, Event
 import os
-from six.moves.configparser import NoOptionError
+from configparser import NoOptionError
 
 from trollsift import compose, Parser
 from posttroll import message

--- a/pytroll_collectors/triggers/_inotify.py
+++ b/pytroll_collectors/triggers/_inotify.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012, 2014, 2015, 2019 Martin Raspaud
+# Copyright (c) 2012 - 2021 Pytroll developers
 #
 # Author(s):
 #

--- a/pytroll_collectors/triggers/_posttroll.py
+++ b/pytroll_collectors/triggers/_posttroll.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012, 2014, 2015, 2019 Martin Raspaud
+# Copyright (c) 2012 - 2021 Pytroll developers
 #
 # Author(s):
 #

--- a/pytroll_collectors/triggers/_watchdog.py
+++ b/pytroll_collectors/triggers/_watchdog.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014-2021, Pytroll developers
+# Copyright (c) 2014 - 2021 Pytroll developers
 #
 # Author(s):
 #

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bdist_rpm]
 provides=pytroll_collectors
-requires=posttroll trollsift python-inotify python-netifaces python-watchdog pytroll-schedule six pyyaml
+requires=posttroll trollsift python-inotify python-netifaces python-watchdog pytroll-schedule pyyaml
 
 no-autoreq=True
 release=20121210-1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014 - 2021, Pytroll developers
+# Copyright (c) 2014 - 2021 Pytroll developers
 #
 # Author(s):
 #
@@ -70,8 +70,8 @@ setup(name="pytroll_collectors",
       install_requires=['pyinotify', 'posttroll>=1.3.0',
                         'trollsift', 'netifaces', 'watchdog',
                         'pytroll-schedule',
-                        'six', 'pyyaml'],
-      tests_require=['trollsift', 'six', 'netifaces', 'watchdog', 'posttroll', 'pyyaml', 'pyinotify'],
+                        'pyyaml'],
+      tests_require=['trollsift', 'netifaces', 'watchdog', 'posttroll', 'pyyaml', 'pyinotify'],
       extras_require=extras_require,
       python_requires='>=3.7',
       )


### PR DESCRIPTION
This PR removes the now-obsolete usage of `six` compatibility library, closes #87 .

There were also two "hacks" to make Python 2 work, which were removed. And the headers in each file were harmonized.