### PR TITLE
Add capability to monitor for silence in geographic gathering

### DIFF
--- a/pytroll_collectors/tests/test_region_collector.py
+++ b/pytroll_collectors/tests/test_region_collector.py
@@ -110,12 +110,14 @@ def test_adjust_timeout(europe, caplog):
             "uri": "file://alt/0"}
     alt_europe_collector = RegionCollector(
             europe,
+            timeliness=datetime.timedelta(seconds=600),
             granule_duration=datetime.timedelta(seconds=180))
 
     with caplog.at_level(logging.DEBUG):
         alt_europe_collector.collect(
                 {**granule_metadata,
                  "start_time": datetime.datetime(2021, 4, 11, 10, 0)})
+        assert alt_europe_collector.timeout == datetime.datetime(2021, 4, 11, 10, 28)
         alt_europe_collector.collect(
                 {**granule_metadata,
                  "start_time": datetime.datetime(2021, 4, 11, 10, 15)})
@@ -123,6 +125,7 @@ def test_adjust_timeout(europe, caplog):
                 {**granule_metadata,
                  "start_time": datetime.datetime(2021, 4, 11, 10, 12)})
     assert "Adjusted timeout" in caplog.text
+    assert alt_europe_collector.timeout == datetime.datetime(2021, 4, 11, 10, 22)
 
 
 @pytest.mark.skip(reason="test never finishes")


### PR DESCRIPTION
Add an option to monitor for silence in geographic gathering.  This adds a timeout calculation that is triggered at a certain time after the most recent message has arrived.  This allows for early shipping if a reception system has stopped delivering earlier than expected or if the region is defined too large.

Work in progress.  So far only the tests have been added.

- [ ] Closes #86 
- [x] Tests added
- [ ] Fully documented