### PR TITLE
Use only 'path' portion of the URI in `cat.py`

### DIFF
--- a/bin/cat.py
+++ b/bin/cat.py
@@ -33,6 +33,7 @@ import os
 import tempfile
 from bz2 import BZ2File
 from datetime import datetime, timedelta
+from urllib.parse import urlsplit
 
 from trollsift.parser import compose
 from posttroll.publisher import Publish
@@ -131,7 +132,7 @@ def get_aliases(raw_config_str):
 def process_message(msg, config):
     """Process the message."""
     pattern = config["output_file_pattern"]
-    input_files = [item["uri"] for item in msg.data["collection"]]
+    input_files = [urlsplit(item["uri"]).path for item in msg.data["collection"]]
 
     data = msg.data.copy()
     data["proc_time"] = datetime.utcnow()


### PR DESCRIPTION
The current messaging from Trollmoves includes the protocol (`ssh://`, `ftp://` or `file://`) and the network location (`foo.bar.com`) in the URIs within the message data. This causes `cat.py` to crash with

```python
[ERROR: 2021-08-19 05:19:00 : cat] b"Cannot open file 'ssh://sat7-io.fmi.fi/lustre/tmp/data/oper/avhrr/ears/level0/AVHR_HRP_00_M03_20210819012800Z_20210819012900Z_N_O_20210819013127Z' mode r"
```
and ends up writing an empty file, sending a message with the written file, which in turn causes AAPP to crash.

This PR ensures that only the file path portion of the URI is used in `cat.py`.