### PR TITLE
Fix coverage logging for non-file messages in region collector

### DIFF
--- a/pytroll_collectors/region_collector.py
+++ b/pytroll_collectors/region_collector.py
@@ -212,7 +212,8 @@ class RegionCollector(object):
             logger.info("Planned timeout for %s: %s", self.region.description,
                         self.timeout.isoformat())
         else:
-            _log_overlaps_or_not(granule_metadata, self.region, 0)
+            coverage_str = f"is not overlapping region {self.region.description:s}"
+            _log_overlap_message(granule_metadata, coverage_str)
 
     def _set_granule_duration(self, start_time, end_time):
         if self.granule_duration is None:
@@ -308,32 +309,21 @@ def _granule_covers_region(granule_metadata, region):
                         instrument=_get_sensor(granule_metadata))
     coverage = granule_pass.area_coverage(region)
     if coverage > 0:
-        _log_overlaps_or_not(granule_metadata, region, coverage)
+        coverage_str = f"is overlapping region {region.description:s} by fraction {coverage:.5f}"
+        _log_overlap_message(granule_metadata, coverage_str)
         return True
     return False
 
 
-def _log_overlaps_or_not(granule_metadata, region, coverage):
-    if coverage > 0:
-        coverage_str = f"is overlapping region {region.description:s} by fraction {coverage:.5f}"
-    else:
-        coverage_str = f"is not overlapping region {region.description:s}"
-
+def _log_overlap_message(granule_metadata, coverage_str):
     try:
         logger.debug(f"Granule {granule_metadata['uri']:s} {coverage_str:s}")
     except KeyError:
         try:
-            if coverage > 0:
-                negation = ""
-            else:
-                negation = "not "
-
-            logger.debug("Granule with start and end times = %s  %s  "
-                         "is %soverlapping region %s",
+            logger.debug("Granule with start and end times = %s  %s  %s ",
                          str(granule_metadata["start_time"]),
                          str(granule_metadata["end_time"]),
-                         negation,
-                         str(region.description))
+                         coverage_str)
         except KeyError:
             logger.debug("Failed printing debug info...")
             logger.debug("Keys in granule_metadata = %s", str(granule_metadata.keys()))

--- a/pytroll_collectors/tests/test_region_collector.py
+++ b/pytroll_collectors/tests/test_region_collector.py
@@ -237,59 +237,36 @@ def test_faulty_end_time(europe_collector, caplog):
     assert "Adjusted end time" in caplog.text
 
 
-def test_log_overlaps_or_not_file_covers(europe, caplog):
-    """Test logging a file covering the target area."""
-    from pytroll_collectors.region_collector import _log_overlaps_or_not
+def test_log_overlap_message_file_message(caplog):
+    """Test logging a file message."""
+    from pytroll_collectors.region_collector import _log_overlap_message
 
     granule_metadata = {'uri': 'filename'}
     with caplog.at_level(logging.DEBUG):
-        _log_overlaps_or_not(granule_metadata, europe, 42.111111)
-    expected = "Granule filename is overlapping region euro_ma by fraction 42.11111"
+        _log_overlap_message(granule_metadata, "foobar")
+    expected = "Granule filename foobar"
     assert expected in caplog.text
 
 
-def test_log_overlaps_or_not_file_does_not_cover(europe, caplog):
-    """Test logging a file not covering the target area."""
-    from pytroll_collectors.region_collector import _log_overlaps_or_not
-
-    granule_metadata = {'uri': 'filename'}
-    with caplog.at_level(logging.DEBUG):
-        _log_overlaps_or_not(granule_metadata, europe, 0)
-    expected = "Granule filename is not overlapping region euro_ma"
-    assert expected in caplog.text
-
-
-def test_log_overlaps_or_not_dataset_covers(europe, caplog):
-    """Test logging a dataset covering the target area."""
-    from pytroll_collectors.region_collector import _log_overlaps_or_not
+def test_log_overlap_message_dataset_message(caplog):
+    """Test logging a dataset message."""
+    from pytroll_collectors.region_collector import _log_overlap_message
 
     granule_metadata = {'dataset': [{'uri': 'filename1'}, {'uri': 'filename2'}],
                         'start_time': 1, 'end_time': 2}
     with caplog.at_level(logging.DEBUG):
-        _log_overlaps_or_not(granule_metadata, europe, 42.111111)
-    expected = "Granule with start and end times = 1  2  is overlapping region euro_ma"
+        _log_overlap_message(granule_metadata, "foobar")
+    expected = "Granule with start and end times = 1  2  foobar"
     assert expected in caplog.text
 
 
-def test_log_overlaps_or_not_dataset_does_not_cover(europe, caplog):
-    """Test logging a dataset not covering the target area."""
-    from pytroll_collectors.region_collector import _log_overlaps_or_not
-
-    granule_metadata = {'dataset': [{'uri': 'filename1'}, {'uri': 'filename2'}],
-                        'start_time': 1, 'end_time': 2}
-    with caplog.at_level(logging.DEBUG):
-        _log_overlaps_or_not(granule_metadata, europe, 0)
-    expected = "Granule with start and end times = 1  2  is not overlapping region euro_ma"
-    assert expected in caplog.text
-
-
-def test_log_overlaps_or_not_backup_log_message(europe, caplog):
+def test_log_overlap_message_backup_log_message(caplog):
     """Test the fallback log messaging."""
-    from pytroll_collectors.region_collector import _log_overlaps_or_not
+    from pytroll_collectors.region_collector import _log_overlap_message
 
     granule_metadata = {'key1': 'val1', 'key2': 'val2'}
     with caplog.at_level(logging.DEBUG):
-        _log_overlaps_or_not(granule_metadata, europe, 42.111111)
+        _log_overlap_message(granule_metadata, "foobar")
     assert "Failed printing debug info" in caplog.text
     assert "Keys in granule_metadata" in caplog.text
     assert "['key1', 'key2']" in caplog.text


### PR DESCRIPTION
The current logging assumes `uri` is directly reachable at the top-level of the incoming message. This is true only for `file` messages, and fails with a `KeyError` for messages with types `dataset` and `collection`.

This PR refactors the logging for "this file covers/does not cover" messages so that the logging doesn't make the thread crash and the whole program hang.