### PR TITLE
Replace `yaml.load()` with `yaml.safe_load()` in `zipcollector_runner.py`

### DIFF
--- a/bin/zipcollector_runner.py
+++ b/bin/zipcollector_runner.py
@@ -105,7 +105,7 @@ def get_arguments():
 def get_config(configfile, service, procenv):
     """Get the configuration from file."""
     with open(configfile, 'r') as fp_:
-        config = yaml.load(fp_)
+        config = yaml.safe_load(fp_)
 
     options = {}
     for item in config:


### PR DESCRIPTION
Pyyaml 6.0 removed the usage of `yaml.load()` without the `Loader` defined. This PR replaces the lone use of `yaml.load()` with `yaml.safe_load()` in `zipcollector_runner.py`.