### PR TITLE
Add return status for the run method and exit status of the main

### DIFF
--- a/bin/geographic_gatherer.py
+++ b/bin/geographic_gatherer.py
@@ -23,6 +23,7 @@
 
 """Gather messages of granules that cover geographic regions together and send them as a collection."""
 
+import sys
 import time
 import logging
 import logging.handlers
@@ -100,11 +101,14 @@ def main():
         return
 
     granule_triggers = GeographicGatherer(config, opts)
-    granule_triggers.run()
+    status = granule_triggers.run()
 
     logger.info("GeographicGatherer has stopped.")
 
+    return status
 
 if __name__ == '__main__':
 
-    main()
+    status = main()
+    
+    sys.exit(status)

--- a/bin/geographic_gatherer.py
+++ b/bin/geographic_gatherer.py
@@ -110,5 +110,5 @@ def main():
 if __name__ == '__main__':
 
     status = main()
-    
+
     sys.exit(status)

--- a/pytroll_collectors/geographic_gatherer.py
+++ b/pytroll_collectors/geographic_gatherer.py
@@ -52,6 +52,7 @@ class GeographicGatherer(object):
         self._opts = opts
         self.publisher = None
         self.triggers = []
+        self.return_status = 0
 
         self._clean_config()
         self._setup_publisher()
@@ -203,8 +204,11 @@ class GeographicGatherer(object):
             logger.info("Shutting down...")
         except (RuntimeError, OSError):
             logger.exception('Something went wrong')
+            self.return_status = 1
         finally:
             logger.info('Ending publication the gathering of granules...')
             for trigger in self.triggers:
                 trigger.stop()
             self.publisher.stop()
+
+        return self.return_status


### PR DESCRIPTION
Part of the problem in issue 100 is that the geographic gatherer exit with 0 after this error. This causes the supervisor to not restart the gatherer. 

Here I add an exit status of 1 if the exception RuntimeError or OSError is raised. This will cause the supervisor to restart the application. If this is a persisting problem, supervisor will try a configured number of times( I think 3 is the default) before it stops.

I think this at least mitigate but not solve the actual problem in 100.

