### PR TITLE
Refactor the fsspec to message functions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U pytest pytest-cov trollsift netifaces watchdog posttroll pyyaml pyinotify pyresample \
-          pytroll-schedule s3fs python-dateutil
+          pytroll-schedule s3fs python-dateutil paramiko
       - name: Install pytroll-collectors
         run: |
           pip install --no-deps -e .

--- a/pytroll_collectors/fsspec_to_message.py
+++ b/pytroll_collectors/fsspec_to_message.py
@@ -1,0 +1,104 @@
+"""Function to create posttroll message containing fsspec filesystem specifications."""
+
+import json
+import os
+
+from fsspec import get_filesystem_class
+from posttroll.message import Message
+
+
+def create_message(fs, file, subject, metadata=None):
+    """Create a message to send."""
+    if isinstance(file, (list, tuple)):
+        file_data = {'dataset': []}
+        for file_item in file:
+            file_data['dataset'].append(_create_message_metadata(fs, file_item))
+        message_type = 'dataset'
+    else:
+        file_data = _create_message_metadata(fs, file)
+        message_type = 'file'
+    if metadata:
+        file_data.update(metadata)
+    return Message(subject, message_type, file_data)
+
+
+def _create_message_metadata(fs, file):
+    """Create a message to send."""
+    loaded_fs = json.loads(fs)
+    uri = _create_uri(file, loaded_fs)
+    uid = _create_uid_from_uri(uri, loaded_fs)
+    base_data = {'filesystem': loaded_fs, 'uri': uri, 'uid': uid}
+    base_data.update(file.get('metadata', dict()))
+    return base_data
+
+
+def _create_uri(file, loaded_fs):
+    protocol = loaded_fs["protocol"]
+    if protocol == 'abstract' and 'zip' in loaded_fs['cls']:
+        protocol = 'zip'
+    uri = protocol + '://' + file['name']
+    return uri
+
+
+def _create_uid_from_uri(uri, loaded_fs):
+    uid = uri
+    if 'target_protocol' in loaded_fs:
+        uid += '::' + loaded_fs['target_protocol'] + '://' + (loaded_fs.get('fo') or loaded_fs['args'][0])
+    return uid
+
+
+def filelist_to_messages(fs, files, subject):
+    """Convert filelist to a list of posttroll messages."""
+    return [create_message(fs.to_json(), file, subject) for file in files]
+
+
+def filelist_unzip_to_messages(fs, files, subject):
+    """Unzip files in filelist if necessary, create posttroll messages."""
+    messages = []
+    for file in files:
+        packing = None
+        file, filename = _get_filename(file, fs)
+        if filename.endswith('.zip'):
+            packing = "zip"
+        elif filename.endswith('.tar'):
+            packing = "tar"
+        messages.append(extract_files_to_message(file, fs, subject, packing))
+
+    return messages
+
+
+def extract_files_to_message(file, fs, subject, packing=None):
+    """Try extracting a file virtually and create the corresponding message.
+
+    If the file is not an archive, create a message with the original file instead.
+    """
+    file, filename = _get_filename(file, fs)
+
+    if packing is None:
+        return create_message(fs.to_json(), file, subject)
+
+    fs_class = get_filesystem_class(packing)
+
+    protocol = _get_fs_protocol(fs)
+    packfs = fs_class(fo=filename,
+                      target_protocol=protocol,
+                      target_options=fs.storage_options)
+    file_list = list(packfs.find('/', detail=True).values())
+    return create_message(packfs.to_json(), file_list, subject, file.get('metadata'))
+
+
+def _get_filename(file, fs):
+    try:
+        filename = file["name"]
+    except TypeError:
+        filename = os.fspath(file)
+        file = fs.info(file)
+    return file, filename
+
+
+def _get_fs_protocol(fs):
+    if isinstance(fs.protocol, (list, tuple)):
+        protocol = fs.protocol[0]
+    else:
+        protocol = fs.protocol
+    return protocol

--- a/pytroll_collectors/fsspec_to_message.py
+++ b/pytroll_collectors/fsspec_to_message.py
@@ -2,20 +2,21 @@
 
 import json
 import os
+import socket
 
 from fsspec import get_filesystem_class
 from posttroll.message import Message
 
 
-def create_message(fs, file, subject, metadata=None):
+def create_message_with_json_fs(fs_to_json, file, subject, metadata=None):
     """Create a message to send."""
     if isinstance(file, (list, tuple)):
         file_data = {'dataset': []}
         for file_item in file:
-            file_data['dataset'].append(_create_message_metadata(fs, file_item))
+            file_data['dataset'].append(_create_message_metadata(fs_to_json, file_item))
         message_type = 'dataset'
     else:
-        file_data = _create_message_metadata(fs, file)
+        file_data = _create_message_metadata(fs_to_json, file)
         message_type = 'file'
     if metadata:
         file_data.update(metadata)
@@ -25,31 +26,50 @@ def create_message(fs, file, subject, metadata=None):
 def _create_message_metadata(fs, file):
     """Create a message to send."""
     loaded_fs = json.loads(fs)
-    uri = _create_uri(file, loaded_fs)
-    uid = _create_uid_from_uri(uri, loaded_fs)
+    uid = _create_uid(file, loaded_fs)
+    uri = _create_uid_from_uri(uid, loaded_fs)
     base_data = {'filesystem': loaded_fs, 'uri': uri, 'uid': uid}
     base_data.update(file.get('metadata', dict()))
     return base_data
 
 
-def _create_uri(file, loaded_fs):
+def _create_uid(file, loaded_fs):
     protocol = loaded_fs["protocol"]
     if protocol == 'abstract' and 'zip' in loaded_fs['cls']:
         protocol = 'zip'
-    uri = protocol + '://' + file['name']
+    netloc = create_netloc(loaded_fs)
+    uid = protocol + '://' + netloc + file['name']
+    return uid
+
+
+def _create_uid_from_uri(uid, loaded_fs):
+    uri = uid
+    if 'target_protocol' in loaded_fs:
+        netloc = create_netloc(loaded_fs['target_options'])
+        uri += '::' + loaded_fs['target_protocol'] + '://' + netloc + (loaded_fs.get('fo') or loaded_fs['args'][0])
     return uri
 
 
-def _create_uid_from_uri(uri, loaded_fs):
-    uid = uri
-    if 'target_protocol' in loaded_fs:
-        uid += '::' + loaded_fs['target_protocol'] + '://' + (loaded_fs.get('fo') or loaded_fs['args'][0])
-    return uid
+def create_netloc(ssh):
+    """Create the netloc from ssh parameters like `host`, `port`, `username`, `password`."""
+    host = ssh.get("host")
+    if host is None:
+        return ""
+    username = ssh.get("username")
+    password = ssh.get("password")
+    port = ssh.get("port")
+    userpass = (
+        username + ((":" + password) if password is not None else "") + "@"
+        if username is not None
+        else ""
+    )
+    netloc = host + ((":" + str(port)) if port is not None else "")
+    return userpass + netloc
 
 
 def filelist_to_messages(fs, files, subject):
     """Convert filelist to a list of posttroll messages."""
-    return [create_message(fs.to_json(), file, subject) for file in files]
+    return [create_message_with_json_fs(fs.to_json(), file, subject) for file in files]
 
 
 def filelist_unzip_to_messages(fs, files, subject):
@@ -75,7 +95,7 @@ def extract_files_to_message(file, fs, subject, packing=None):
     file, filename = _get_filename(file, fs)
 
     if packing is None:
-        return create_message(fs.to_json(), file, subject)
+        return create_message_with_json_fs(fs.to_json(), file, subject)
 
     fs_class = get_filesystem_class(packing)
 
@@ -84,7 +104,34 @@ def extract_files_to_message(file, fs, subject, packing=None):
                       target_protocol=protocol,
                       target_options=fs.storage_options)
     file_list = list(packfs.find('/', detail=True).values())
-    return create_message(packfs.to_json(), file_list, subject, file.get('metadata'))
+    return create_message_with_json_fs(packfs.to_json(), file_list, subject, file.get('metadata'))
+
+
+def extract_local_files_to_message_for_remote_use(filename, subject, packing=None,
+                                                  target_protocol=None, target_options=None):
+    """Try extracting a file virtually and create the corresponding message.
+
+    If the file is not an archive, create a message with the original file instead.
+    """
+    if packing is None:
+        cls = get_filesystem_class(target_protocol or "ssh")
+        cls = ".".join((cls.__module__, cls.__name__))
+        target_options = target_options or dict(host=socket.gethostname())
+        fs_dict = dict(cls=cls,
+                       protocol=target_protocol or "ssh",
+                       args=[],
+                       **target_options
+                       )
+        file = dict(name=filename)
+    else:
+        fs_class = get_filesystem_class(packing)
+        packfs = fs_class(fo=os.fspath(filename))
+        file = list(packfs.find('/', detail=True).values())
+        fs_dict = json.loads(packfs.to_json())
+        fs_dict["target_protocol"] = target_protocol or "ssh"
+        fs_dict["target_options"] = target_options or {"host": socket.gethostname(), "protocol": "ssh"}
+
+    return create_message_with_json_fs(json.dumps(fs_dict), file, subject)
 
 
 def _get_filename(file, fs):

--- a/pytroll_collectors/tests/test_fsspec_to_message.py
+++ b/pytroll_collectors/tests/test_fsspec_to_message.py
@@ -1,0 +1,146 @@
+"""Tests for the fsspec to message features."""
+
+from copy import deepcopy
+import os
+import pytest
+
+import pytroll_collectors.fsspec_to_message
+from pytroll_collectors.tests.test_s3stalker import ls_output, fs_json, subject, zip_content, zip_json, zip_json_fo
+
+
+class TestMessageComposer:
+    """Test case for the message composer."""
+
+    def setup(self):
+        """Set up message composer tests."""
+        self.ls_output = deepcopy(ls_output)
+
+    def test_message_is_created_with_fs(self):
+        """Test the message is created with a filesystem."""
+        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject)
+        assert 'filesystem' in message.data
+        assert message.data['filesystem'] == {"cls": "s3fs.core.S3FileSystem",
+                                              "protocol": "s3", "args": [], "anon": True}
+
+    def test_message_is_created_with_uri(self):
+        """Test message has a uri."""
+        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject)
+        assert 'uri' in message.data
+        assert message.data['uri'] == 's3://' + self.ls_output[0]['name']
+
+    def test_message_is_created_with_uid(self):
+        """Test message has a uid."""
+        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject)
+        assert 'uid' in message.data
+
+    def test_message_is_created_with_file(self):
+        """Test message has a type of file."""
+        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject)
+        assert message.type == 'file'
+
+    def test_message_is_created_with_dataset(self):
+        """Test message is created with dataset."""
+        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output, subject)
+        assert 'dataset' in message.data
+        assert len(message.data['dataset']) > 0
+        filenames = ["s3://" + item['name'] for item in self.ls_output]
+        for item in message.data['dataset']:
+            assert item['uri'] in filenames
+        assert message.type == 'dataset'
+
+    def test_message_from_zip_is_created_with_uri(self):
+        """Test message has a uri."""
+        zip_output = list(zip_content.values())
+        message = pytroll_collectors.fsspec_to_message.create_message(zip_json, zip_output[0], subject)
+        assert 'uri' in message.data
+        assert message.data['uri'] == 'zip://' + zip_output[0]['name']
+
+    def test_message_from_zip_with_fo_is_created_with_uri(self):
+        """Test message has a uri."""
+        zip_output = list(zip_content.values())
+        message = pytroll_collectors.fsspec_to_message.create_message(zip_json_fo, zip_output[0], subject)
+        assert 'uri' in message.data
+        assert message.data['uri'] == 'zip://' + zip_output[0]['name']
+
+    def test_message_include_file_metadata(self):
+        """Test message has metadata."""
+        self.ls_output[0]['metadata'] = dict(platform_name='S3A')
+        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject)
+        assert message.data['platform_name'] == 'S3A'
+
+    def test_message_include_metadata_parameter(self):
+        """Test message has metadata from parameter."""
+        metadata = dict(platform_name='S3A')
+        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject, metadata)
+        assert message.data['platform_name'] == 'S3A'
+
+
+def create_tar_file(filenames, path):
+    """Create a tarred file."""
+    from tarfile import TarFile
+
+    with TarFile(path, mode="w") as packfile:
+        for filename in filenames:
+            packfile.add(filename)
+
+
+def create_zip_file(filenames, path):
+    """Create a zipped file."""
+    from zipfile import ZipFile
+
+    with ZipFile(path, mode="w") as packfile:
+        for filename in filenames:
+            packfile.write(filename)
+
+
+def create_pack_path(tmp_path):
+    """Create the pack path."""
+    pack_path = tmp_path / "pack"
+    os.mkdir(pack_path)
+    return pack_path
+
+
+class TestUnpackMessage:
+    """Test unpacking a file to message."""
+
+    def create_files_to_pack(self, tmp_path):
+        """Create files to pack."""
+        filenames = []
+        for filename_number in range(10):
+            filename = tmp_path / f"file_to_pack{filename_number}.txt"
+            with open(filename, mode="w") as fd:
+                fd.write("Very important stuff.\n")
+            filenames.append(filename)
+        return filenames
+
+    @pytest.mark.parametrize(
+        ("packing", "create_packfile", "filesystem_class"),
+        [
+            ("tar", create_tar_file, "fsspec.implementations.tar.TarFileSystem"),
+            ("zip", create_zip_file, "fsspec.implementations.zip.ZipFileSystem"),
+        ]
+    )
+    def test_pack_file_extract(self, packing, create_packfile, filesystem_class, tmp_path):
+        """Test extracting packed files."""
+        filenames = self.create_files_to_pack(tmp_path)
+
+        pack_path = create_pack_path(tmp_path)
+        path = pack_path / ("packfile." + packing)
+        create_packfile(filenames, path)
+
+        from pytroll_collectors.fsspec_to_message import extract_files_to_message
+        import fsspec
+        fs = fsspec.filesystem("file")
+        packed_file = path
+        topic = "interesting_topic"
+        msg = extract_files_to_message(packed_file, fs, topic, packing)
+        expected_data = {"dataset": [
+            {"filesystem": {"cls": filesystem_class,
+                            "protocol": packing, "args": [],
+                            "fo": f"{path}",
+                            "target_protocol": "file", "target_options": {}},
+             "uri": f"{packing}:/{filename}",
+             "uid": f"{packing}:/{filename}::file://{path}"} for filename in filenames]}
+
+        assert msg.data == expected_data
+        assert msg.subject == topic

--- a/pytroll_collectors/tests/test_fsspec_to_message.py
+++ b/pytroll_collectors/tests/test_fsspec_to_message.py
@@ -1,11 +1,12 @@
 """Tests for the fsspec to message features."""
-
+import socket
 from copy import deepcopy
 import os
 import pytest
 
 import pytroll_collectors.fsspec_to_message
 from pytroll_collectors.tests.test_s3stalker import ls_output, fs_json, subject, zip_content, zip_json, zip_json_fo
+from pytroll_collectors.fsspec_to_message import extract_local_files_to_message_for_remote_use
 
 
 class TestMessageComposer:
@@ -17,30 +18,30 @@ class TestMessageComposer:
 
     def test_message_is_created_with_fs(self):
         """Test the message is created with a filesystem."""
-        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject)
+        message = pytroll_collectors.fsspec_to_message.create_message_with_json_fs(fs_json, self.ls_output[0], subject)
         assert 'filesystem' in message.data
         assert message.data['filesystem'] == {"cls": "s3fs.core.S3FileSystem",
                                               "protocol": "s3", "args": [], "anon": True}
 
     def test_message_is_created_with_uri(self):
         """Test message has a uri."""
-        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject)
+        message = pytroll_collectors.fsspec_to_message.create_message_with_json_fs(fs_json, self.ls_output[0], subject)
         assert 'uri' in message.data
         assert message.data['uri'] == 's3://' + self.ls_output[0]['name']
 
     def test_message_is_created_with_uid(self):
         """Test message has a uid."""
-        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject)
+        message = pytroll_collectors.fsspec_to_message.create_message_with_json_fs(fs_json, self.ls_output[0], subject)
         assert 'uid' in message.data
 
     def test_message_is_created_with_file(self):
         """Test message has a type of file."""
-        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject)
+        message = pytroll_collectors.fsspec_to_message.create_message_with_json_fs(fs_json, self.ls_output[0], subject)
         assert message.type == 'file'
 
     def test_message_is_created_with_dataset(self):
         """Test message is created with dataset."""
-        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output, subject)
+        message = pytroll_collectors.fsspec_to_message.create_message_with_json_fs(fs_json, self.ls_output, subject)
         assert 'dataset' in message.data
         assert len(message.data['dataset']) > 0
         filenames = ["s3://" + item['name'] for item in self.ls_output]
@@ -48,30 +49,33 @@ class TestMessageComposer:
             assert item['uri'] in filenames
         assert message.type == 'dataset'
 
-    def test_message_from_zip_is_created_with_uri(self):
+    def test_message_from_zip_is_created_with_uid(self):
         """Test message has a uri."""
         zip_output = list(zip_content.values())
-        message = pytroll_collectors.fsspec_to_message.create_message(zip_json, zip_output[0], subject)
-        assert 'uri' in message.data
-        assert message.data['uri'] == 'zip://' + zip_output[0]['name']
+        message = pytroll_collectors.fsspec_to_message.create_message_with_json_fs(zip_json, zip_output[0], subject)
+        assert 'uid' in message.data
+        assert message.data['uid'] == 'zip://' + zip_output[0]['name']
 
-    def test_message_from_zip_with_fo_is_created_with_uri(self):
+    def test_message_from_zip_with_fo_is_created_with_uid(self):
         """Test message has a uri."""
         zip_output = list(zip_content.values())
-        message = pytroll_collectors.fsspec_to_message.create_message(zip_json_fo, zip_output[0], subject)
-        assert 'uri' in message.data
-        assert message.data['uri'] == 'zip://' + zip_output[0]['name']
+        message = pytroll_collectors.fsspec_to_message.create_message_with_json_fs(zip_json_fo, zip_output[0], subject)
+        assert 'uid' in message.data
+        assert message.data['uid'] == 'zip://' + zip_output[0]['name']
 
     def test_message_include_file_metadata(self):
         """Test message has metadata."""
         self.ls_output[0]['metadata'] = dict(platform_name='S3A')
-        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject)
+        message = pytroll_collectors.fsspec_to_message.create_message_with_json_fs(fs_json, self.ls_output[0], subject)
         assert message.data['platform_name'] == 'S3A'
 
     def test_message_include_metadata_parameter(self):
         """Test message has metadata from parameter."""
         metadata = dict(platform_name='S3A')
-        message = pytroll_collectors.fsspec_to_message.create_message(fs_json, self.ls_output[0], subject, metadata)
+        message = pytroll_collectors.fsspec_to_message.create_message_with_json_fs(fs_json,
+                                                                                   self.ls_output[0],
+                                                                                   subject,
+                                                                                   metadata)
         assert message.data['platform_name'] == 'S3A'
 
 
@@ -139,8 +143,80 @@ class TestUnpackMessage:
                             "protocol": packing, "args": [],
                             "fo": f"{path}",
                             "target_protocol": "file", "target_options": {}},
-             "uri": f"{packing}:/{filename}",
-             "uid": f"{packing}:/{filename}::file://{path}"} for filename in filenames]}
+             "uid": f"{packing}:/{filename}",
+             "uri": f"{packing}:/{filename}::file://{path}"} for filename in filenames]}
+
+        assert msg.data == expected_data
+        assert msg.subject == topic
+
+    @pytest.mark.parametrize(
+        ("packing", "create_packfile", "filesystem_class"),
+        [
+            ("tar", create_tar_file, "fsspec.implementations.tar.TarFileSystem"),
+            ("zip", create_zip_file, "fsspec.implementations.zip.ZipFileSystem"),
+        ]
+    )
+    def test_pack_local_file_extract(self, packing, create_packfile, filesystem_class, tmp_path):
+        """Test extracting packed files."""
+        filenames = self.create_files_to_pack(tmp_path)
+
+        pack_path = create_pack_path(tmp_path)
+        path = pack_path / ("packfile." + packing)
+        create_packfile(filenames, path)
+
+        packed_file = path
+        topic = "interesting_topic"
+        msg = extract_local_files_to_message_for_remote_use(packed_file, topic, packing=packing)
+        host = socket.gethostname()
+        expected_data = {"dataset": [
+            {"filesystem": {"cls": filesystem_class,
+                            "protocol": packing, "args": [],
+                            "fo": f"{path}",
+                            "target_protocol": "ssh", "target_options": {"protocol": "ssh", "host": host}},
+             "uid": f"{packing}:/{filename}",
+             "uri": f"{packing}:/{filename}::ssh://{host}{path}"} for filename in filenames]}
+        from pprint import pprint
+        pprint(expected_data)
+        assert msg.data == expected_data
+        assert msg.subject == topic
+
+    @pytest.mark.parametrize(
+        ("packing", "create_packfile", "filesystem_class"),
+        [
+            ("tar", create_tar_file, "fsspec.implementations.tar.TarFileSystem"),
+            ("zip", create_zip_file, "fsspec.implementations.zip.ZipFileSystem"),
+        ]
+    )
+    def test_pack_local_file_extract_with_custom_options(self, packing, create_packfile, filesystem_class, tmp_path):
+        """Test extracting packed files using custom options."""
+        filenames = self.create_files_to_pack(tmp_path)
+
+        pack_path = create_pack_path(tmp_path)
+        path = pack_path / ("packfile." + packing)
+        create_packfile(filenames, path)
+
+        packed_file = path
+        topic = "interesting_topic"
+        host = socket.gethostname()
+        username = "me"
+        password = "mysecurepass"
+        protocol = "ssh"
+        port = 22
+        target_options = {"host": socket.gethostname(),
+                          "username": username,
+                          "password": password,
+                          "protocol": protocol,
+                          "port": port}
+        msg = extract_local_files_to_message_for_remote_use(packed_file, topic,
+                                                            target_options=target_options, packing=packing)
+        expected_data = {"dataset": [
+            {"filesystem": {"cls": filesystem_class,
+                            "protocol": packing, "args": [],
+                            "fo": f"{path}",
+                            "target_protocol": protocol, "target_options": target_options},
+             "uid": f"{packing}:/{filename}",
+             "uri": f"{packing}:/{filename}::{protocol}://{username}:{password}@{host}:{port}{path}"}
+            for filename in filenames]}
 
         assert msg.data == expected_data
         assert msg.subject == topic

--- a/pytroll_collectors/tests/test_s3stalker.py
+++ b/pytroll_collectors/tests/test_s3stalker.py
@@ -1052,7 +1052,7 @@ class TestFileListUnzipToMessages(unittest.TestCase):
 
     @mock.patch('s3fs.S3FileSystem')
     @mock.patch('pytroll_collectors.fsspec_to_message.get_filesystem_class')
-    def test_file_list_unzip_to_messages_returns_messages_with_list_of_zip_content_in_uri(self, zip_fs, s3_fs):
+    def test_file_list_unzip_to_messages_returns_messages_with_list_of_zip_content_in_uid(self, zip_fs, s3_fs):
         """Test zip content is included in messages."""
         from pytroll_collectors import s3stalker
         path = "sentinel-s3-ol2wfr-zips/2020/11/21"
@@ -1063,12 +1063,12 @@ class TestFileListUnzipToMessages(unittest.TestCase):
         fs, files = s3stalker.get_last_files(path, anon=True)
         message_list = pytroll_collectors.fsspec_to_message.filelist_unzip_to_messages(fs, files, subject)
         exp_file_list = ['zip://' + file['name'] for file in zip_content.values()]
-        file_list = [file['uri'] for file in message_list[1].data['dataset']]
+        file_list = [file['uid'] for file in message_list[1].data['dataset']]
         assert file_list == exp_file_list
 
     @mock.patch('s3fs.S3FileSystem')
     @mock.patch('pytroll_collectors.fsspec_to_message.get_filesystem_class')
-    def test_file_list_unzip_to_messages_returns_messages_with_list_of_zip_content_in_uid(self, zip_fs, s3_fs):
+    def test_file_list_unzip_to_messages_returns_messages_with_list_of_zip_content_in_uri(self, zip_fs, s3_fs):
         """Test zip content is included in messages."""
         from pytroll_collectors import s3stalker
         path = "sentinel-s3-ol2wfr-zips/2020/11/21"
@@ -1080,7 +1080,7 @@ class TestFileListUnzipToMessages(unittest.TestCase):
         message_list = pytroll_collectors.fsspec_to_message.filelist_unzip_to_messages(fs, files, subject)
         zip_file = ls_output[1]['name']
         exp_file_list = ['zip://' + file['name'] + '::s3://' + zip_file for file in zip_content.values()]
-        file_list = [file['uid'] for file in message_list[1].data['dataset']]
+        file_list = [file['uri'] for file in message_list[1].data['dataset']]
         assert file_list == exp_file_list
 
     @mock.patch('s3fs.S3FileSystem')


### PR DESCRIPTION
This PR refactors the fsspec to message functions to make them more easily reusable.

@paulovcmedeiros you might be interested in this.

This needs https://github.com/fsspec/filesystem_spec/pull/950 to work fully