### PR TITLE
Confirm configuration file was read in gatherer.

### DIFF
--- a/pytroll_collectors/geographic_gatherer.py
+++ b/pytroll_collectors/geographic_gatherer.py
@@ -45,7 +45,11 @@ class GeographicGatherer:
     def __init__(self, opts):
         """Initialize the class."""
         self._config = ConfigParser(interpolation=None)
-        self._config.read(opts.config)
+        # ConfigParser.read silently ignores unreadable files...
+        read = self._config.read(opts.config)
+        if not read:
+            raise OSError(f"Could not read configuration file {opts.config:s}. "
+                          "Please make sure it exists and is readable.")
 
         self._opts = opts
         self.publisher = None

--- a/pytroll_collectors/tests/test_geographic_gatherer.py
+++ b/pytroll_collectors/tests/test_geographic_gatherer.py
@@ -318,6 +318,16 @@ class TestGeographicGatherer:
         fake_create_publisher_from_dict_config.assert_called_once_with(expected)
         fake_create_publisher_from_dict_config.return_value.start.assert_called_once()
 
+    def test_fails_unreadable_config(self, tmp_path):
+        from pytroll_collectors.geographic_gatherer import GeographicGatherer
+        opts = arg_parse(["/thıs/fıle/does/not/exıst"])
+        with pytest.raises(OSError):
+            GeographicGatherer(opts)
+        os.chmod(os.fspath(tmp_path), 0)
+        opts = arg_parse([os.fspath(tmp_path)])
+        with pytest.raises(OSError):
+            GeographicGatherer(opts)
+
 
 def assert_create_publisher_from_dict_config(sections, port, nameservers):
     """Check that publisher creator has been called correctly."""

--- a/pytroll_collectors/tests/test_geographic_gatherer.py
+++ b/pytroll_collectors/tests/test_geographic_gatherer.py
@@ -321,11 +321,15 @@ class TestGeographicGatherer:
     def test_fails_unreadable_config(self, tmp_path):
         from pytroll_collectors.geographic_gatherer import GeographicGatherer
         opts = arg_parse(["/thıs/fıle/does/not/exıst"])
-        with pytest.raises(OSError):
+        with pytest.raises(
+                OSError,
+                match="Could not read configuration file /thıs/fıle/does/not/exıst"):
             GeographicGatherer(opts)
         os.chmod(os.fspath(tmp_path), 0)
         opts = arg_parse([os.fspath(tmp_path)])
-        with pytest.raises(OSError):
+        with pytest.raises(
+                OSError,
+                match=f"Could not read configuration file {tmp_path!s}"):
             GeographicGatherer(opts)
 
 


### PR DESCRIPTION
Confirm the configuration file was read successfully when initialising
the geographic gatherer.

Fixes #72.