### PR TITLE
When adding to existing timeslot, indicate which one

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -777,7 +777,8 @@ class SegmentGatherer(object):
             time_slot = self.slots[slot].output_metadata[self.time_name]
             time_diff = time_obj - time_slot
             if abs(time_diff.total_seconds()) < self._time_tolerance:
-                logger.debug("Found existing time slot, using that")
+                logger.debug("Found existing time slot at %s, using that",
+                             str(time_slot))
                 return slot
 
         return str(time_obj)

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -972,8 +972,10 @@ class TestSegmentGathererCollections(unittest.TestCase):
         viirs_msg = Message_p(rawstr=viirs_message)
         pps_msg = Message_p(rawstr=pps_message)
 
-        self.collection_gatherer.process(viirs_msg)
-        self.collection_gatherer.process(pps_msg)
+        with self._caplog.at_level(logging.DEBUG):
+            self.collection_gatherer.process(viirs_msg)
+            self.collection_gatherer.process(pps_msg)
+        assert "Found existing time slot at 2020-10-13 05:17:21.200000, using that" in self._caplog.text
 
         slot = self.collection_gatherer.slots['2020-10-13 05:17:21.200000']
         assert slot.get_status() == Status.SLOT_READY


### PR DESCRIPTION
In the debug message informing that an existing timeslot had been found,
indicate what timeslot this was.