### PR TITLE
Publish the correct end_time in the segment gatherer

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -365,6 +365,7 @@ class Slot:
         # add uri, uid and sensor
 
         self._add_file_info_to_metadata(metadata, message)
+        self._update_metadata_times(metadata, message)
 
         # Collect all sensors, not only the latest
         sensors = metadata.get('sensor', [])
@@ -387,6 +388,13 @@ class Slot:
             metadata['dataset'].extend(message.message_data['dataset'])
         else:
             raise NotImplementedError('Cannot handle message of type: ' + str(message.type))
+
+    def _update_metadata_times(self, metadata, message):
+        """Update start/end time when message added to metadata."""
+        if "start_time" in metadata and "start_time" in message.message_data:
+            metadata["start_time"] = min(metadata["start_time"], message.message_data["start_time"])
+        if "end_time" in metadata and "end_time" in message.message_data:
+            metadata["end_time"] = max(metadata["end_time"], message.message_data["end_time"])
 
     def is_relevant(self, message):
         """Check if the message is relevant to this slot."""

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -59,7 +59,8 @@ fake_config = {
             "critical_files": None,
             "wanted_files": ":001-003",
             "all_files": ":001-003",
-            "is_critical_set": False}},
+            "is_critical_set": False,
+            "variable_tags": ["start_time", "end_time"]}},
     "timeliness": 10,
     "group_by_minutes": 10,
     "time_name": "start_time"}
@@ -1079,7 +1080,7 @@ class TestSegmentGathererCollections(unittest.TestCase):
             sg.process(msg)
         assert len(sg.slots) == 1
         assert sg.slots["1980-01-01 13:00:00"].output_metadata["start_time"] == dt.datetime(1980, 1, 1, 13, 0, 0)
-        assert sg.slots["1980-01-01 13:00:00"].output_metadata["end_time"] == dt.datetime(1980, 1, 1, 13, 0, 3)
+        assert sg.slots["1980-01-01 13:00:00"].output_metadata["end_time"] == dt.datetime(1980, 1, 1, 13, 3, 0)
 
 
 pps_message1 = ('pytroll://segment/CF/2/CMA/norrkoping/utv/polar/direct_readout/ file safusr.u@lxserv1043.smhi.se '


### PR DESCRIPTION
Publish the correct end_time in the segment_gatherer when using group_by_minutes.

- [x] Tests added
- [x] Tests passed
- [x] Fixes #112 