### PR TITLE
Catch KeyError from collector from missing TLE

### DIFF
--- a/pytroll_collectors/tests/test_region_collector.py
+++ b/pytroll_collectors/tests/test_region_collector.py
@@ -64,10 +64,20 @@ METOP-C
 _granule_metadata = {"platform_name": "Metop-C",
                      "sensor": "avhrr"}
 
+_granule_metadata_metop_b = {"platform_name": "Metop-B",
+                             "sensor": "avhrr"}
 
 def granule_metadata(s_min):
     """Return common granule_metadata dictionary."""
     return {**_granule_metadata,
+            "start_time": datetime.datetime(2021, 4, 11, 10, s_min, 0),
+            "end_time": datetime.datetime(2021, 4, 11, 10, s_min+3, 0),
+            "uri": f"file://{s_min:d}"}
+
+
+def granule_metadata_metop_b(s_min):
+    """Return common granule_metadata dictionary."""
+    return {**_granule_metadata_metop_b,
             "start_time": datetime.datetime(2021, 4, 11, 10, s_min, 0),
             "end_time": datetime.datetime(2021, 4, 11, 10, s_min+3, 0),
             "uri": f"file://{s_min:d}"}
@@ -196,6 +206,15 @@ def test_collect_check_schedules_custom_method_failed(europe_collector_schedule_
     test_string = ("Failed to import schedule_cut for harvest_schedules from failed_not_existing_module. "
                    "Will not perform schedule cut.")
     assert test_string in caplog.text
+
+
+@unittest.mock.patch("pyorbital.tlefile.urlopen", new=_fakeopen)
+def test_collect_missing_tle_from_file(europe_collector, caplog):
+    """Test that granules can be collected, but missing TLE raises and exception"""
+    with caplog.at_level(logging.DEBUG):
+        for s_min in (0, 3, 6, 9, 12, 15, 18):
+            with pytest.raises(KeyError):
+                europe_collector.collect({**granule_metadata_metop_b(s_min)})
 
 
 @unittest.mock.patch("pyorbital.tlefile.urlopen", new=_fakeopen)

--- a/pytroll_collectors/triggers/_base.py
+++ b/pytroll_collectors/triggers/_base.py
@@ -77,13 +77,20 @@ class Trigger:
 
     def _process_metadata(self, metadata):
         """Execute the collectors and publish the collection."""
+        print(metadata)
         if not metadata:
             logger.warning("No metadata")
             return
         for collector in self.collectors:
-            res = collector(metadata.copy())
-            if res:
-                self.publish_collection(res)
+            print("coll", collector)
+            try:
+                res = collector(metadata.copy())
+            except KeyError as ke:
+                print("after", str(ke))
+                logger.exception("collector failed with: %s ",str(ke))
+            else:
+                if res:
+                    self.publish_collection(res)
 
     def publish_collection(self, metadata):
         """Terminate the gathering."""


### PR DESCRIPTION
Now and then I get for some reason an exception as described in #30

What happens is then that the subscriber for this area stops and thus can not continue collecting new segments.
Other regions continue to work if there are more. Or the the geographic gatherer just continue to run.

One way to handle this, as proposed in this PR, is to catch the KeyError exception and then continue keeping the subscriber running. Therefore at the next run it will try again and it will still work.

I think this is better than just stop working. At least it tries again.

Another way is to do this is to make the whole geographic gatherer stop and then leave to the user how he or she will handle this. But this will affect all the regions in the gatherer.