### PR TITLE
Ensure files in S3 keep their full URIs in messages

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -68,7 +68,6 @@ class Status(Enum):
 
 DO_NOT_COPY_KEYS = ("uid", "uri", "channel_name", "segment", "sensor")
 REMOVE_TAGS = {'path', 'segment'}
-SUPPORTED_REMOTE_SCHEMES = ('s3', )
 
 
 class Parser(metaclass=ABCMeta):
@@ -382,13 +381,7 @@ class Slot:
     def _add_file_info_to_metadata(self, metadata, message):
         msg_data = message.message_data
         if message.type == 'file':
-            url_parts = urlparse(msg_data['uri'])
-            if url_parts.scheme in SUPPORTED_REMOTE_SCHEMES:
-                uri = msg_data['uri']
-            else:
-                uri = url_parts.path
-            uid = msg_data['uid']
-            metadata['dataset'].append({'uri': uri, 'uid': uid})
+            metadata['dataset'].append({'uri': msg_data['uri'], 'uid': msg_data['uid']})
         elif message.type == 'dataset':
             metadata['dataset'].extend(message.message_data['dataset'])
         else:

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -68,6 +68,7 @@ class Status(Enum):
 
 DO_NOT_COPY_KEYS = ("uid", "uri", "channel_name", "segment", "sensor")
 REMOVE_TAGS = {'path', 'segment'}
+SUPPORTED_REMOTE_SCHEMES = ('s3', )
 
 
 class Parser(metaclass=ABCMeta):
@@ -381,7 +382,11 @@ class Slot:
     def _add_file_info_to_metadata(self, metadata, message):
         msg_data = message.message_data
         if message.type == 'file':
-            uri = urlparse(msg_data['uri']).path
+            url_parts = urlparse(msg_data['uri'])
+            if url_parts.scheme in SUPPORTED_REMOTE_SCHEMES:
+                uri = msg_data['uri']
+            else:
+                uri = url_parts.path
             uid = msg_data['uid']
             metadata['dataset'].append({'uri': uri, 'uid': uid})
         elif message.type == 'dataset':

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -491,7 +491,7 @@ class TestSegmentGatherer(unittest.TestCase):
         slot = col.slots[time_slot]
         _ = slot.add_file(message)
         meta = col.slots[time_slot].output_metadata
-        self.assertTrue(meta['dataset'][0]['uri'].startswith('/home/lahtinep/data/satellite/geo/msg/'))
+        self.assertTrue(meta['dataset'][0]['uri'].startswith('file:///home/lahtinep/data/satellite/geo/msg/'))
 
     def test_add_two_files(self):
         """Test adding two files."""


### PR DESCRIPTION
This PR makes sure that segments collected from S3 keep their full URIs. Previously the scheme and bucket name were stripped away.