### PR TITLE
Fix import error in bin/trollstalker2.py

### DIFF
--- a/bin/trollstalker2.py
+++ b/bin/trollstalker2.py
@@ -37,7 +37,7 @@ import os.path
 from posttroll.publisher import NoisyPublisher
 from posttroll.message import Message
 from trollsift import Parser
-from pytroll_collectors.trigger import AbstractWatchDogProcessor
+from pytroll_collectors.triggers._watchdog import AbstractWatchDogProcessor
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes #127

This fix required accessing protected member `_watchdog` of module `pytroll_collectors.triggers`.