### PR TITLE
Bugfix segment gathering when segment name has a dash in it

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -302,18 +302,9 @@ class Slot:
                         'segment' not in parser.fmt):
                     result.add(parser.globify(meta))
                 continue
-            segments = segments.split('-')
-            if len(segments) > 1:
-                format_string = '%d'
-                if len(segments[0]) > 1 and segments[0][0] == '0':
-                    format_string = '%0' + str(len(segments[0])) + 'd'
-                try:
-                    segments = [format_string % i
-                                for i in range(int(segments[0]),
-                                               int(segments[-1]) + 1)]
-                except ValueError:
-                    # The segment name had a dash, it wasn't a range
-                    segments = ['-'.join(segments)]
+
+            segments = _create_segment_list(segments)
+
             meta['channel_name'] = channel_name
             for seg in segments:
                 meta['segment'] = seg
@@ -480,6 +471,24 @@ class Slot:
             return Status.SLOT_NONCRITICAL_NOT_READY
         if Status.SLOT_READY_BUT_WAIT_FOR_MORE in status_values:
             return Status.SLOT_READY_BUT_WAIT_FOR_MORE
+
+
+def _create_segment_list(segments):
+    segments = segments.split('-')
+    if len(segments) == 2:
+        try:
+            range_start = int(segments[0])
+            range_end = int(segments[-1]) + 1
+        except ValueError:
+            segments = ['-'.join(segments)]
+        else:
+            format_string = '%d'
+            if len(segments[0]) > 1 and segments[0][0] == '0':
+                format_string = '%0' + str(len(segments[0])) + 'd'
+            segments = [format_string % i
+                        for i in range(range_start,
+                                       range_end)]
+    return segments
 
 
 class Pattern:

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -307,9 +307,13 @@ class Slot:
                 format_string = '%d'
                 if len(segments[0]) > 1 and segments[0][0] == '0':
                     format_string = '%0' + str(len(segments[0])) + 'd'
-                segments = [format_string % i
-                            for i in range(int(segments[0]),
-                                           int(segments[-1]) + 1)]
+                try:
+                    segments = [format_string % i
+                                for i in range(int(segments[0]),
+                                               int(segments[-1]) + 1)]
+                except ValueError:
+                    # The segment name had a dash, it wasn't a range
+                    segments = ['-'.join(segments)]
             meta['channel_name'] = channel_name
             for seg in segments:
                 meta['segment'] = seg

--- a/pytroll_collectors/tests/data/segments_nwcsaf_geo.ini
+++ b/pytroll_collectors/tests/data/segments_nwcsaf_geo.ini
@@ -1,0 +1,13 @@
+[nwcsaf_geo]
+pattern = S_NWC_{segment}_{orig_platform_name:4s}_MSG-N-VISIR_{start_time:%Y%m%dT%H%M%S}Z.nc
+critical_files = :CT,:CMA,:CTTH,:CRR,:CMIC,:CRR-Ph
+wanted_files = :CT,:CMA,:CTTH,:CRR,:CMIC,:CRR-Ph
+all_files = :CT,:CMA,:CTTH,:CRR,:CMIC
+topics = /nwc_geo/0deg/ct /nwc_geo/0deg/cma /nwc_geo/0deg/ctth /nwc_geo/0deg/crr /nwc_geo/0deg/cmic
+publish_topic = /nwc_geo/0deg/segment
+# timeliness = 1200
+timeliness = 1800
+time_name = start_time
+check_existing_files_after_start = true
+nameservers = localhost
+publish_port = 40004

--- a/pytroll_collectors/tests/data/segments_nwcsaf_geo.ini
+++ b/pytroll_collectors/tests/data/segments_nwcsaf_geo.ini
@@ -5,7 +5,6 @@ wanted_files = :CT,:CMA,:CTTH,:CRR,:CMIC,:CRR-Ph
 all_files = :CT,:CMA,:CTTH,:CRR,:CMIC
 topics = /nwc_geo/0deg/ct /nwc_geo/0deg/cma /nwc_geo/0deg/ctth /nwc_geo/0deg/crr /nwc_geo/0deg/cmic
 publish_topic = /nwc_geo/0deg/segment
-# timeliness = 1200
 timeliness = 1800
 time_name = start_time
 check_existing_files_after_start = true

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -191,81 +191,68 @@ class TestSegmentGatherer(unittest.TestCase):
         self.assertEqual(len(slot['msg']['wanted_files']), 38)
         self.assertEqual(len(slot['msg']['all_files']), 114)
 
-    def test_compose_filenames(self):
-        """Test composing the filenames."""
+    def test_compose_filenames_explicit_segments(self):
+        """Test composing the filenames when segment names don't need expansion."""
         mda = self.mda_msg0deg.copy()
-        fake_message = FakeMessage(mda)
-        message = Message(fake_message, self.msg0deg._patterns['msg'])
-        self.msg0deg._create_slot(message)
-        slot_str = str(mda["start_time"])
-        slot = self.msg0deg.slots[slot_str]
-        parser = self.msg0deg._patterns['msg'].parser
-
-        fname_set = slot.compose_filenames(parser,
-                                           self.msg0deg._patterns['msg']['critical_files'])
+        segment_list = self.msg0deg._patterns['msg']['critical_files']
+        fname_set = self._get_filenames(self.msg0deg, mda, 'msg', segment_list)
         self.assertTrue(fname_set, set)
         self.assertEqual(len(fname_set), 2)
         self.assertTrue("H-000-MSG3__-MSG3________-_________-PRO______-201611281100-__" in fname_set)
         self.assertTrue("H-000-MSG3__-MSG3________-_________-EPI______-201611281100-__" in fname_set)
-        fname_set = slot.compose_filenames(parser, None)
-        self.assertEqual(len(fname_set), 0)
-        # Check that MSG segments can be given as range, and the
-        # result is same as with explicit segment names
-        fname_set_range = slot.compose_filenames(
-            parser,
-            self.msg0deg._patterns['msg']['wanted_files'])
-        fname_set_explicit = slot.compose_filenames(
-            parser,
-            self.msg0deg._patterns['msg']['all_files'])
-        self.assertEqual(len(fname_set_range), len(fname_set_explicit))
-        self.assertEqual(len(fname_set_range.difference(fname_set_explicit)), 0)
 
-        # Tests using filesets with no segments
-        mda = self.mda_hrpt.copy()
+    @staticmethod
+    def _get_filenames(segment_gatherer, mda, section, segment_list):
         fake_message = FakeMessage(mda)
-        message = Message(fake_message, self.hrpt_pps._patterns['hrpt'])
-        self.hrpt_pps._create_slot(message)
+        message = Message(fake_message, segment_gatherer._patterns[section])
+        segment_gatherer._create_slot(message)
+        parser = segment_gatherer._patterns[section].parser
         slot_str = str(mda["start_time"])
-        slot = self.hrpt_pps.slots[slot_str]
-        parser = self.hrpt_pps._patterns['hrpt'].parser
+        slot = segment_gatherer.slots[slot_str]
+        return slot.compose_filenames(parser, segment_list)
 
-        fname_set = slot.compose_filenames(
-            parser,
-            self.hrpt_pps._patterns['hrpt']['critical_files'])
+    def test_compose_filenames_none(self):
+        """Test composing the filenames when no segments are defined in the config."""
+        mda = self.mda_msg0deg.copy()
+        fname_set = self._get_filenames(self.msg0deg, mda, 'msg', None)
+        self.assertEqual(len(fname_set), 0)
+
+    def test_compose_filenames_range_of_segments(self):
+        """Test that the segments can be defined with numeric ranges."""
+        mda = self.mda_msg0deg.copy()
+        segment_list = self.msg0deg._patterns['msg']['wanted_files']
+        fname_set = self._get_filenames(self.msg0deg, mda, 'msg', segment_list)
+        self.assertEqual(len(fname_set), 10)
+
+    def test_compose_filenames_no_segments_undefined_variable_tag(self):
+        """Test using filesets with no segments and a single un-typed variable tag."""
+        mda = self.mda_hrpt.copy()
+        segment_list = self.hrpt_pps._patterns['hrpt']['critical_files']
+        fname_set = self._get_filenames(self.hrpt_pps, mda, 'hrpt', segment_list)
         self.assertEqual(len(fname_set), 1)
         self.assertTrue("hrpt_*_20180319_0955_28538.l1b" in fname_set)
-        parser = self.hrpt_pps._patterns['pps'].parser
-        fname_set = slot.compose_filenames(
-            parser,
-            self.hrpt_pps._patterns['pps']['critical_files'])
+
+    def test_compose_filenames_no_segments_typed_variable_tags(self):
+        """Test using filesets with no segments and typed variable tags."""
+        mda = self.mda_pps.copy()
+        segment_list = self.hrpt_pps._patterns['pps']['critical_files']
+        fname_set = self._get_filenames(self.hrpt_pps, mda, 'pps', segment_list)
         self.assertEqual(len(fname_set), 1)
         self.assertTrue(
             "S_NWC_CMA_*_28538_20180319T0955???Z_????????T???????Z.nc" in fname_set)
 
-        # Tests using filesets with no segments, INI config
+    def test_compose_filenames_no_segments_ini_config(self):
+        """Test using filesets with no segments, INI config."""
         mda = self.mda_goes16.copy()
-        fake_message = FakeMessage(mda)
-        message = Message(fake_message, self.goes_ini._patterns['goes16'])
-        self.goes_ini._create_slot(message)
-        slot_str = str(mda["start_time"])
-        slot = self.goes_ini.slots[slot_str]
-        parser = self.goes_ini._patterns['goes16'].parser
-        fname_set = slot.compose_filenames(
-            parser,
-            self.goes_ini._patterns['goes16']['critical_files'])
+        segment_list = self.goes_ini._patterns['goes16']['critical_files']
+        fname_set = self._get_filenames(self.goes_ini, mda, 'goes16', segment_list)
         self.assertEqual(len(fname_set), 0)
 
-        # NWC SAF GEO, where a segment name has a dash in it (CRR-Ph)
+    def test_compose_filenames_dash_in_segment_name(self):
+        """Test a segment name has a dash in it (CRR-Ph)."""
         mda = self.mda_nwcsaf_geo.copy()
-        fake_message = FakeMessage(mda)
-        message = Message(fake_message, self.nwcsaf_geo._patterns['nwcsaf_geo'])
-        self.nwcsaf_geo._create_slot(message)
-        slot_str = str(mda["start_time"])
-        slot = self.nwcsaf_geo.slots[slot_str]
-        parser = self.nwcsaf_geo._patterns['nwcsaf_geo'].parser
-        fname_set = slot.compose_filenames(
-            parser,
-            self.nwcsaf_geo._patterns['nwcsaf_geo']['critical_files'])
+        segment_list = self.nwcsaf_geo._patterns['nwcsaf_geo']['critical_files']
+        fname_set = self._get_filenames(self.nwcsaf_geo, mda, 'nwcsaf_geo', segment_list)
         self.assertTrue("S_NWC_CRR-Ph_MSG4_MSG-N-VISIR_20230214T130000Z.nc" in fname_set)
 
     def test_update_timeout(self):


### PR DESCRIPTION
This is a fix for segment gathering case where a segment name has a dash in it, like `CRR-Ph`.

The filename composition tests were refactored along the way.