### PR TITLE
Make it possible to tell segment gatherer that all the files are local

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -378,6 +378,12 @@ check_existing_files_after_start
     that should also be added to this time slot. Currently does not support
     (remote) S3 filesystems. Defaults to False.
 
+all_files_are_local
+    Optional.  If set to ``True`` (defaults to ``False``), segment gatherer will handle
+    all files as locally accessible. That is, it will drop the transport protocol/scheme
+    and host name from the URI of the incoming messages. The use case is for protocols that
+    ``fsspec`` do not recognize and can't handle, such as ``scp://``.
+
 The YAML format supports collection of several different data together. As
 an example: SEVIRI data and NWC SAF GEO products.
 

--- a/examples/segment_gatherer.ini_template
+++ b/examples/segment_gatherer.ini_template
@@ -24,6 +24,8 @@ variable_tags = proctime,proc_decimal
 # addresses = tcp://192.168.0.101:12345 tcp://192.168.0.102:12345
 # Publish messages via this port.  If not set, random free port is used
 # publish_port = 12345
+# Force all files to be local. That is, drop scheme and host from the URIs before handling the messages
+# all_files_are_local = True
 
 # nameserver host to register publisher
 # WARNING: 

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -158,10 +158,12 @@ class MessageParser(Parser):
 class Message:
     """A message object."""
 
-    def __init__(self, posttroll_message, pattern):
+    def __init__(self, posttroll_message, pattern, drop_scheme=False):
         """Set up the message."""
         self.pattern = pattern
-        self.message_data = posttroll_message.data.copy()
+        self._drop_scheme = drop_scheme
+        posttroll_message = self._check_scheme(posttroll_message)
+        self.message_data = posttroll_message.data
         self.type = posttroll_message.type
         self._posttroll_message = posttroll_message
         self.metadata = pattern.parser.parse(self.message_data)
@@ -190,6 +192,24 @@ class Message:
         time_item = dt.datetime(time_item.year, time_item.month,
                                 time_item.day, time_item.hour, floor_minutes, 0)
         metadata[time_name] = time_item
+
+    def _check_scheme(self, posttroll_message):
+        message_data = posttroll_message.data.copy()
+        if self._drop_scheme:
+            url_parts = urlparse(message_data['uri'])
+            uri = urlunparse(
+                (
+                    '',
+                    '',
+                    url_parts.path,
+                    '',
+                    '',
+                    ''
+                )
+            )
+            message_data['uri'] = uri
+            posttroll_message.data = message_data
+        return posttroll_message
 
     @property
     def filtered_metadata(self):
@@ -782,7 +802,8 @@ class SegmentGatherer(object):
         for pattern in self._patterns.values():
             try:
                 if pattern.parser.matches(msg):
-                    return Message(msg, pattern)
+                    drop_scheme = self._config.get('all_files_are_local', False)
+                    return Message(msg, pattern, drop_scheme=drop_scheme)
             except KeyError as err:
                 logger.debug("No key %s in message.", str(err))
         raise TypeError
@@ -997,6 +1018,11 @@ def ini_to_dict(fname, section):
         conf['check_existing_files_after_start'] = config.getboolean(section, "check_existing_files_after_start")
     except (NoOptionError, ValueError):
         conf['check_existing_files_after_start'] = False
+
+    try:
+        conf['all_files_are_local'] = config.getboolean(section, "all_files_are_local")
+    except (NoOptionError, ValueError):
+        conf['all_files_are_local'] = False
 
     return conf
 

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -162,7 +162,7 @@ class Message:
         """Set up the message."""
         self.pattern = pattern
         self._drop_scheme = drop_scheme
-        posttroll_message = self._check_scheme(posttroll_message)
+        posttroll_message = self._handle_scheme(posttroll_message)
         self.message_data = posttroll_message.data
         self.type = posttroll_message.type
         self._posttroll_message = posttroll_message
@@ -193,7 +193,7 @@ class Message:
                                 time_item.day, time_item.hour, floor_minutes, 0)
         metadata[time_name] = time_item
 
-    def _check_scheme(self, posttroll_message):
+    def _handle_scheme(self, posttroll_message):
         message_data = posttroll_message.data.copy()
         if self._drop_scheme:
             url_parts = urlparse(message_data['uri'])

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -80,8 +80,7 @@ class FakeMessage:
 class TestSegmentGatherer:
     """Tests for the segment gatherer."""
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_method(self):
         """Set up the testing."""
         self.mda_msg0deg = {"segment": "EPI", "uid": "H-000-MSG3__-MSG3________-_________-EPI______-201611281100-__", "platform_shortname": "MSG3", "start_time": dt.datetime(2016, 11, 28, 11, 0, 0), "nominal_time": dt.datetime(  # noqa
             2016, 11, 28, 11, 0, 0), "uri": "/home/lahtinep/data/satellite/geo/msg/H-000-MSG3__-MSG3________-_________-EPI______-201611281100-__", "platform_name": "Meteosat-10", "channel_name": "", "path": "", "sensor": ["seviri"], "hrit_format": "MSG3"}  # noqa

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -446,6 +446,16 @@ class TestSegmentGatherer:
             logs = [rec.message for rec in caplog.records]
             assert 'No parser matching message, skipping.' in logs
 
+    def test_process_message_force_local_files(self):
+        """Test processing message with scheme when config says files are local and existing files are checked."""
+        mda = self.mda_msg0deg.copy()
+        mda['uri'] = 'SCHEME://' + mda['uri']
+        msg = FakeMessage(mda)
+        col = SegmentGatherer(CONFIG_SINGLE)
+        col._config['check_existing_files_after_start'] = True
+        col._config['all_files_are_local'] = True
+        col.process(msg)
+
     def test_add_single_file(self):
         """Test adding a file."""
         msg = FakeMessage(self.mda_msg0deg)

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -459,6 +459,18 @@ class TestSegmentGatherer:
         uri = slot.output_metadata['dataset'][0]['uri']
         assert uri == expected_uri
 
+    def test_process_message_force_local_files_check_existing(self):
+        """Test processing message with scheme when config says files are local and existing files are checked."""
+        mda = self.mda_msg0deg.copy()
+        mda['uri'] = 'SCHEME://host.foo.bar' + mda['uri']
+        msg = FakeMessage(mda)
+        col = SegmentGatherer(CONFIG_SINGLE)
+        # Without forcing all files to be local the processing would fail with
+        # "ValueError: Protocol not known: scheme"
+        col._config['all_files_are_local'] = True
+        col._config['check_existing_files_after_start'] = True
+        col.process(msg)
+
     def test_add_single_file(self):
         """Test adding a file."""
         msg = FakeMessage(self.mda_msg0deg)

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -1046,8 +1046,7 @@ new_pps_message_data = \
 class TestSegmentGathererCollections:
     """Test collections gathering."""
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_method(self):
         """Set up the test case."""
         self.collection_gatherer = SegmentGatherer(CONFIG_COLLECTIONS)
 
@@ -1285,8 +1284,7 @@ class TestMessage:
 class TestFlooring:
     """Test flooring."""
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_method(self):
         """Set up the test case."""
         self.himawari_ini = SegmentGatherer(CONFIG_INI_HIMAWARI)
 
@@ -1342,8 +1340,7 @@ class TestFlooring:
 class TestFlooringMultiplePatterns:
     """Test flooring."""
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_method(self):
         """Set up the test case."""
         self.iodc_himawari = SegmentGatherer(CONFIG_DOUBLE_DIFFERENT)
 

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -447,14 +447,17 @@ class TestSegmentGatherer:
             assert 'No parser matching message, skipping.' in logs
 
     def test_process_message_force_local_files(self):
-        """Test processing message with scheme when config says files are local and existing files are checked."""
+        """Test processing message with scheme when config says files are local."""
         mda = self.mda_msg0deg.copy()
+        expected_uri = mda['uri']
         mda['uri'] = 'SCHEME://' + mda['uri']
         msg = FakeMessage(mda)
         col = SegmentGatherer(CONFIG_SINGLE)
-        col._config['check_existing_files_after_start'] = True
         col._config['all_files_are_local'] = True
         col.process(msg)
+        slot = col.slots[str(mda['start_time'])]
+        uri = slot.output_metadata['dataset'][0]['uri']
+        assert uri == expected_uri
 
     def test_add_single_file(self):
         """Test adding a file."""

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -450,7 +450,7 @@ class TestSegmentGatherer:
         """Test processing message with scheme when config says files are local."""
         mda = self.mda_msg0deg.copy()
         expected_uri = mda['uri']
-        mda['uri'] = 'SCHEME://' + mda['uri']
+        mda['uri'] = 'SCHEME://host.foo.bar' + mda['uri']
         msg = FakeMessage(mda)
         col = SegmentGatherer(CONFIG_SINGLE)
         col._config['all_files_are_local'] = True

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -76,7 +76,6 @@ class FakeMessage:
         self.subject = subject
 
 
-@pytest.mark.usefixtures("caplog")
 class TestSegmentGatherer:
     """Tests for the segment gatherer."""
 


### PR DESCRIPTION
With this PR it is possible to set a configuration option (`all_files_are_local = True`) that tells segment gatherer all the files to be local independent of the possible transport scheme (for example `scp://`) or host (`foo.bar.com`) in the received message metadata URI.