### PR TITLE
Fix calling s3.ls() to get also new files for the daemon version

### DIFF
--- a/pytroll_collectors/s3stalker.py
+++ b/pytroll_collectors/s3stalker.py
@@ -92,7 +92,7 @@ def _reset_last_fetch_from_file_list(files):
 
 
 def _get_files_since_last_fetch(fs, path):
-    files = fs.ls(path, detail=True)
+    files = fs.ls(path, detail=True, refresh=True)
     logger.debug(f"Get files since {get_last_fetch()}")
     files = list(filter((lambda x: x['LastModified'] > get_last_fetch()), files))
     return files

--- a/pytroll_collectors/tests/test_s3stalker.py
+++ b/pytroll_collectors/tests/test_s3stalker.py
@@ -1204,3 +1204,13 @@ def test_get_configs_from_command_line_gets_bucket_from_config_when_not_provided
     assert config == S3_STALKER_CONFIG
     assert bucket == "s3://bucket_from_file/"
     assert log_config == {}
+
+
+@mock.patch('s3fs.S3FileSystem')
+def test_get_last_files_ls_args(S3FileSystem):
+    """Test that s3.ls() in get_last_files() is called with correct arguments."""
+    from pytroll_collectors.s3stalker import get_last_files
+
+    _ = get_last_files('path')
+
+    S3FileSystem.return_value.ls.assert_called_once_with('path', detail=True, refresh=True)


### PR DESCRIPTION
The `s3.ls()` call was missing `refresh=True` kwarg that is required by the daemon version of the S3Stalker. Without it, the call results are taken from cache and none of the new files are returned.