### PR TITLE
Drop S3 credentials from messages in S3Stalker (+ daemon)

### DIFF
--- a/pytroll_collectors/fsspec_to_message.py
+++ b/pytroll_collectors/fsspec_to_message.py
@@ -26,9 +26,14 @@ def create_message_with_json_fs(fs_to_json, file, subject, metadata=None):
 def _create_message_metadata(fs, file):
     """Create a message to send."""
     loaded_fs = json.loads(fs)
+    loaded_fs.pop('key', None)
+    loaded_fs.pop('secret', None)
+    if 'client_kwargs' in loaded_fs:
+        loaded_fs['client_kwargs'].pop('aws_access_key_id', None)
+        loaded_fs['client_kwargs'].pop('aws_secret_access_key', None)
     uid = _create_uid(file, loaded_fs)
     uri = _create_uri_from_uid(uid, loaded_fs)
-    base_data = {'uri': uri, 'uid': uid}
+    base_data = {'filesystem': loaded_fs, 'uri': uri, 'uid': uid}
     base_data.update(file.get('metadata', dict()))
     return base_data
 

--- a/pytroll_collectors/fsspec_to_message.py
+++ b/pytroll_collectors/fsspec_to_message.py
@@ -28,7 +28,7 @@ def _create_message_metadata(fs, file):
     loaded_fs = json.loads(fs)
     uid = _create_uid(file, loaded_fs)
     uri = _create_uri_from_uid(uid, loaded_fs)
-    base_data = {'filesystem': loaded_fs, 'uri': uri, 'uid': uid}
+    base_data = {'uri': uri, 'uid': uid}
     base_data.update(file.get('metadata', dict()))
     return base_data
 

--- a/pytroll_collectors/tests/test_fsspec_to_message.py
+++ b/pytroll_collectors/tests/test_fsspec_to_message.py
@@ -300,3 +300,18 @@ class TestSingleFile:
         with pytest.raises(RuntimeError):
             _ = extract_local_files_to_message_for_remote_use(filename, topic,
                                                               target_options=target_options)
+
+
+def test_message_has_no_filesystem():
+    """Test that 'secret' and 'key' are stripped from the message."""
+    import datetime as dt
+    from dateutil import tz
+    from pytroll_collectors.fsspec_to_message import create_message_with_json_fs
+
+    jsn = ('{"cls": "s3fs.core.S3FileSystem", "protocol": "s3", "args": [], '
+           '"client_kwargs": {"endpoint_url": "https://lake.fmi.fi"}, "secret": "xxx", "key": "yyy", "anon": false}')
+    file_ = {'key': 'bucket/test.bin', 'LastModified': dt.datetime.now(tz.UTC),
+             'name': 'bucket/test.bin', 'metadata': {}}
+    msg = create_message_with_json_fs(jsn, file_, '/subject')
+
+    assert 'filesystem' not in msg.data

--- a/pytroll_collectors/tests/test_fsspec_to_message.py
+++ b/pytroll_collectors/tests/test_fsspec_to_message.py
@@ -309,9 +309,14 @@ def test_message_has_no_filesystem():
     from pytroll_collectors.fsspec_to_message import create_message_with_json_fs
 
     jsn = ('{"cls": "s3fs.core.S3FileSystem", "protocol": "s3", "args": [], '
-           '"client_kwargs": {"endpoint_url": "https://lake.fmi.fi"}, "secret": "xxx", "key": "yyy", "anon": false}')
+           '"client_kwargs": {"endpoint_url": "https://lake.fmi.fi", '
+           '"aws_access_key_id": "xxx", "aws_secret_access_key": "yyy"}, '
+           '"secret": "xxx", "key": "yyy", "anon": false}')
     file_ = {'key': 'bucket/test.bin', 'LastModified': dt.datetime.now(tz.UTC),
              'name': 'bucket/test.bin', 'metadata': {}}
     msg = create_message_with_json_fs(jsn, file_, '/subject')
 
-    assert 'filesystem' not in msg.data
+    assert 'secret' not in msg.data['filesystem']
+    assert 'key' not in msg.data['filesystem']
+    assert 'aws_access_key_id' not in msg.data['filesystem']['client_kwargs']
+    assert 'aws_secret_access_key' not in msg.data['filesystem']['client_kwargs']


### PR DESCRIPTION
The messages published by S3Stalker(daemon) had all the credentials published in the messages. ~This PR drops the whole `filesystem` part of the message, which needs to be configured at the receiving side in any case.~

Update: only drop known S3 credentials.