### PR TITLE
Collect and publish data for multiple different time slots

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -588,30 +588,25 @@ class SegmentGatherer(object):
         """Initialize the segment gatherer."""
         self._config = config.copy()
         self._pattern_configs = self._config.pop('patterns')
-        self._subject = None
         self._timeliness = dt.timedelta(seconds=config.get("timeliness", 1200))
-
         # This get the 'keep_parsed_keys' valid for all patterns
         self._keep_parsed_keys = self._config.get('keep_parsed_keys', [])
-
-        self._patterns = self._create_patterns()
-
-        self._elements = list(self._patterns.keys())
-
         self._time_tolerance = self._config.get("time_tolerance", 30)
         self._bundle_datasets = self._config.get("bundle_datasets", False)
-
         self._num_files_premature_publish = self._config.get("num_files_premature_publish", -1)
-
-        self.slots = OrderedDict()
-
         self.time_name = self._config.get('time_name', 'start_time')
         # Floor the scene start time to the given full minutes
         self._group_by_minutes = self._config.get('group_by_minutes', None)
-
-        self._loop = False
         self._providing_server = self._config.get('providing_server')
+        self._multicollection = self._config.get('multicollection')
+
+        self._patterns = self._create_patterns()
+        self._elements = list(self._patterns.keys())
+
+        self.slots = OrderedDict()
+        self._subject = None
         self._is_first_message_after_start = True
+        self._loop = False
 
     def _create_patterns(self):
         return {key: Pattern(key, pattern_config, self._config)

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -702,7 +702,7 @@ class SegmentGatherer(object):
             del output_metadata["collection"]
         return output_metadata
 
-    def _get_multicollection_metadata(time_slot):
+    def _get_multicollection_metadata(self, time_slot):
         raise NotImplementedError
 
     def _publish(self, metadata):

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -1456,16 +1456,20 @@ class TestSegmentGathererFCI:
 
 TEMPORAL_COLLECTION_MESSAGE_1 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
                                  ' {"start_time": "2023-05-24T06:00:00", "uid": "20230524_0600_file_1_1.nc",'
-                                 ' "uri": "/data/20230524_0600_file_1_1.nc", "sensor": ["sensor"]}')
+                                 ' "uri": "/data/20230524_0600_file_1_1.nc", "sensor": ["sensor"],'
+                                 ' "platform_name": "FOO-1"}')
 TEMPORAL_COLLECTION_MESSAGE_2 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
-                                 ' {"start_time": "2023-05-24T07:00:00", "uid": "20230524_0700_file_1_1.nc",'
-                                 ' "uri": "/data/20230524_0700_file_2_1.nc", "sensor": ["sensor"]}')
+                                 ' {"start_time": "2023-05-24T07:00:00", "uid": "20230524_0700_file_2_1.nc",'
+                                 ' "uri": "/data/20230524_0700_file_2_1.nc", "sensor": ["sensor"],'
+                                 ' "platform_name": "FOO-1"}')
 TEMPORAL_COLLECTION_MESSAGE_3 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
-                                 ' {"start_time": "2023-05-24T08:00:00", "uid": "20230524_0800_file_1_1.nc",'
-                                 ' "uri": "/data/20230524_0800_file_3_1.nc", "sensor": ["sensor"]}')
+                                 ' {"start_time": "2023-05-24T08:00:00", "uid": "20230524_0800_file_3_1.nc",'
+                                 ' "uri": "/data/20230524_0800_file_3_1.nc", "sensor": ["sensor"],'
+                                 ' "platform_name": "FOO-1"}')
 TEMPORAL_COLLECTION_MESSAGE_4 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
-                                 ' {"start_time": "2023-05-24T09:00:00", "uid": "20230524_0900_file_1_1.nc",'
-                                 ' "uri": "/data/20230524_0900_file_4_1.nc", "sensor": ["sensor"]}')
+                                 ' {"start_time": "2023-05-24T09:00:00", "uid": "20230524_0900_file_4_1.nc",'
+                                 ' "uri": "/data/20230524_0900_file_4_1.nc", "sensor": ["sensor"],'
+                                 ' "platform_name": "FOO-1"}')
 
 
 class TestTemporalCollection:
@@ -1547,7 +1551,38 @@ class TestTemporalCollection:
             ]
         }
 
-        expected_message_data = ""
+        expected_message_data = {
+            "start_times": ["2023-05-24T06:00:00", "2023-05-24T07:00:00", "2023-05-24T08:00:00", "2023-05-24T09:00:00"],
+            "end_times": [],
+            "platform_name": "FOO-1",
+            "sensor": ["sensor"],
+            "temporal_collection": [
+                {
+                    "start_time": "2023-05-24T06:00:00",
+                    "uid": "20230524_0600_file_1_1.nc",
+                    "uri": "/data/20230524_0600_file_1_1.nc",
+                    "sensor": ["sensor"]
+                },
+                {
+                    "start_time": "2023-05-24T07:00:00",
+                    "uid": "20230524_0700_file_2_1.nc",
+                    "uri": "/data/20230524_0700_file_2_1.nc",
+                    "sensor": ["sensor"]
+                },
+                {
+                    "start_time": "2023-05-24T08:00:00",
+                    "uid": "20230524_0800_file_3_1.nc",
+                    "uri": "/data/20230524_0800_file_3_1.nc",
+                    "sensor": ["sensor"]
+                },
+                {
+                    "start_time": "2023-05-24T09:00:00",
+                    "uid": "20230524_0900_file_4_1.nc",
+                    "uri": "/data/20230524_0900_file_4_1.nc",
+                    "sensor": ["sensor"]
+                },
+            ]
+        }
 
         temporal_collector = SegmentGatherer(config)
         temporal_collector.process(msg_1)

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -1454,35 +1454,35 @@ class TestSegmentGathererFCI:
         assert uids == expected_uids
 
 
-MULTICOLLECTION_MESSAGE_1 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
-                             ' {"start_time": "2023-05-24T06:00:00", "uid": "20230524_0600_file_1_1.nc",'
-                             ' "uri": "/data/20230524_0600_file_1_1.nc", "sensor": ["sensor"]}')
-MULTICOLLECTION_MESSAGE_2 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
-                             ' {"start_time": "2023-05-24T07:00:00", "uid": "20230524_0700_file_1_1.nc",'
-                             ' "uri": "/data/20230524_0700_file_2_1.nc", "sensor": ["sensor"]}')
-MULTICOLLECTION_MESSAGE_3 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
-                             ' {"start_time": "2023-05-24T08:00:00", "uid": "20230524_0800_file_1_1.nc",'
-                             ' "uri": "/data/20230524_0800_file_3_1.nc", "sensor": ["sensor"]}')
-MULTICOLLECTION_MESSAGE_4 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
-                             ' {"start_time": "2023-05-24T09:00:00", "uid": "20230524_0900_file_1_1.nc",'
-                             ' "uri": "/data/20230524_0900_file_4_1.nc", "sensor": ["sensor"]}')
+TEMPORAL_COLLECTION_MESSAGE_1 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
+                                 ' {"start_time": "2023-05-24T06:00:00", "uid": "20230524_0600_file_1_1.nc",'
+                                 ' "uri": "/data/20230524_0600_file_1_1.nc", "sensor": ["sensor"]}')
+TEMPORAL_COLLECTION_MESSAGE_2 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
+                                 ' {"start_time": "2023-05-24T07:00:00", "uid": "20230524_0700_file_1_1.nc",'
+                                 ' "uri": "/data/20230524_0700_file_2_1.nc", "sensor": ["sensor"]}')
+TEMPORAL_COLLECTION_MESSAGE_3 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
+                                 ' {"start_time": "2023-05-24T08:00:00", "uid": "20230524_0800_file_1_1.nc",'
+                                 ' "uri": "/data/20230524_0800_file_3_1.nc", "sensor": ["sensor"]}')
+TEMPORAL_COLLECTION_MESSAGE_4 = ('pytroll://foo/file file user@host 2023-02-21T13:15:47.413168 v1.01 application/json'
+                                 ' {"start_time": "2023-05-24T09:00:00", "uid": "20230524_0900_file_1_1.nc",'
+                                 ' "uri": "/data/20230524_0900_file_4_1.nc", "sensor": ["sensor"]}')
 
 
-class TestMultiCollection:
-    """Test collecting and publishing of multiple segment collections."""
+class TestTemporalCollection:
+    """Test collecting and publishing of temporal collections."""
 
     def test_empty_config(self):
-        """Test that the multicollection attribute exists and is set to None by default."""
+        """Test that the temporal_collection attribute exists and is set to None by default."""
         segment_gatherer = SegmentGatherer({'patterns': dict()})
 
-        assert segment_gatherer._multicollection is None
+        assert segment_gatherer._temporal_collection is None
 
-    def test_multicollection_is_set(self):
-        """Test that the multicollection config items are set correctly."""
-        multicollection = [{'min_age': 0, 'max_age': 0}, {'min_age': 60, 'max_age': 65}]
-        segment_gatherer = SegmentGatherer({'patterns': dict(), 'multicollection': multicollection})
+    def test_temporal_collection_is_set(self):
+        """Test that the temporal collection config items are set correctly."""
+        temporal_collection = [{'min_age': 0, 'max_age': 0}, {'min_age': 60, 'max_age': 65}]
+        segment_gatherer = SegmentGatherer({'patterns': dict(), 'temporal_collection': temporal_collection})
 
-        assert segment_gatherer._multicollection == multicollection
+        assert segment_gatherer._temporal_collection == temporal_collection
 
     def test_clean_obsolete_slots(self, monkeypatch):
         """Test that only slots that are not needed anymore are removed."""
@@ -1503,7 +1503,7 @@ class TestMultiCollection:
 
         config = {
             'patterns': dict(),
-            'multicollection': [{'min_age': 0, 'max_age': 0}, {'min_age': 60, 'max_age': 65}]
+            'temporal_collection': [{'min_age': 0, 'max_age': 0}, {'min_age': 60, 'max_age': 65}]
         }
         segment_gatherer = SegmentGatherer(config)
         slot_keys = ['2023-05-24 06:00:00.000000', '2023-05-24 07:00:00.000000',
@@ -1516,14 +1516,14 @@ class TestMultiCollection:
         assert slot_keys[0] not in segment_gatherer.slots
         assert slot_keys[1] not in segment_gatherer.slots
 
-    def test_multicollection_publishing(self):
-        """Test that metadata for multicollection is collected and published correctly."""
+    def test_temporal_collection_publishing(self):
+        """Test that metadata for temporal_collection is collected and published correctly."""
         from posttroll.message import Message as Message_p
 
-        msg_1 = Message_p(rawstr=MULTICOLLECTION_MESSAGE_1)
-        msg_2 = Message_p(rawstr=MULTICOLLECTION_MESSAGE_2)
-        msg_3 = Message_p(rawstr=MULTICOLLECTION_MESSAGE_3)
-        msg_4 = Message_p(rawstr=MULTICOLLECTION_MESSAGE_4)
+        msg_1 = Message_p(rawstr=TEMPORAL_COLLECTION_MESSAGE_1)
+        msg_2 = Message_p(rawstr=TEMPORAL_COLLECTION_MESSAGE_2)
+        msg_3 = Message_p(rawstr=TEMPORAL_COLLECTION_MESSAGE_3)
+        msg_4 = Message_p(rawstr=TEMPORAL_COLLECTION_MESSAGE_4)
 
         config = {
             "patterns": {
@@ -1538,10 +1538,10 @@ class TestMultiCollection:
                 "topics": [
                     "/foo/file",
                 ],
-                "publish_topic": "/foo/multicollection"
+                "publish_topic": "/foo/temporal_collection"
             },
             "time_name": "start_time",
-            "multicollection": [
+            "temporal_collection": [
                 {"min_age": 0, "max_age": 0},
                 {"min_age": 60, "max_age": 65},
             ]
@@ -1549,19 +1549,19 @@ class TestMultiCollection:
 
         expected_message_data = ""
 
-        multicollector = SegmentGatherer(config)
-        multicollector.process(msg_1)
-        multicollector.process(msg_2)
-        multicollector.process(msg_3)
-        multicollector.process(msg_4)
+        temporal_collector = SegmentGatherer(config)
+        temporal_collector.process(msg_1)
+        temporal_collector.process(msg_2)
+        temporal_collector.process(msg_3)
+        temporal_collector.process(msg_4)
 
-        multicollector._publisher = MagicMock()
-        multicollector._subject = multicollector._config['posttroll']['publish_topic']
-        multicollector.triage_slots()
+        temporal_collector._publisher = MagicMock()
+        temporal_collector._subject = temporal_collector._config['posttroll']['publish_topic']
+        temporal_collector.triage_slots()
         # There should be three sets that match the criteria, so 3 messages should be sent
-        assert multicollector._publisher.send.call_count == 3
-        args, kwargs = multicollector._publisher.send.call_args_list[0]
+        assert temporal_collector._publisher.send.call_count == 3
+        args, kwargs = temporal_collector._publisher.send.call_args_list[0]
         message = Message_p(rawstr=args[0])
         # Should have data from messages 1 and 2
         assert message.data == expected_message_data
-        assert message.type == "multicollection"
+        assert message.type == "temporal_collection"

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -1452,3 +1452,20 @@ class TestSegmentGathererFCI:
         assert len(slot.output_metadata["dataset"]) == 2
         uids = set(info["uid"] for info in slot.output_metadata["dataset"])
         assert uids == expected_uids
+
+
+class TestMultiCollection:
+    """Test collecting and publishing of multiple segment collections."""
+
+    def test_empty_config(self):
+        """Test that the multicollection attribute exists and is set to None by default."""
+        segment_gatherer = SegmentGatherer({'patterns': dict()})
+
+        assert segment_gatherer._multicollection is None
+
+    def test_multicollection_is_set(self):
+        """Test that the multicollection config items are set correctly."""
+        multicollection = [{'min_age': 0, 'max_age': 0}, {'min_age': 60, 'max_age': 65}]
+        segment_gatherer = SegmentGatherer({'patterns': dict(), 'multicollection': multicollection})
+
+        assert segment_gatherer._multicollection == multicollection

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -1552,34 +1552,34 @@ class TestTemporalCollection:
         }
 
         expected_message_data = {
-            "start_times": ["2023-05-24T06:00:00", "2023-05-24T07:00:00", "2023-05-24T08:00:00", "2023-05-24T09:00:00"],
+            "start_times": [dt.datetime(2023, 5, 24, 6, 0, 0), dt.datetime(2023, 5, 24, 7, 0, 0)],
             "end_times": [],
             "platform_name": "FOO-1",
             "sensor": ["sensor"],
             "temporal_collection": [
                 {
-                    "start_time": "2023-05-24T06:00:00",
-                    "uid": "20230524_0600_file_1_1.nc",
-                    "uri": "/data/20230524_0600_file_1_1.nc",
-                    "sensor": ["sensor"]
+                    "start_time": dt.datetime(2023, 5, 24, 6, 0),
+                    "sensor": ["sensor"],
+                    "platform_name": "FOO-1",
+                    "number": 1,
+                    "dataset": [
+                        {
+                            "uid": "20230524_0600_file_1_1.nc",
+                            "uri": "/data/20230524_0600_file_1_1.nc",
+                        }
+                    ]
                 },
                 {
-                    "start_time": "2023-05-24T07:00:00",
-                    "uid": "20230524_0700_file_2_1.nc",
-                    "uri": "/data/20230524_0700_file_2_1.nc",
-                    "sensor": ["sensor"]
-                },
-                {
-                    "start_time": "2023-05-24T08:00:00",
-                    "uid": "20230524_0800_file_3_1.nc",
-                    "uri": "/data/20230524_0800_file_3_1.nc",
-                    "sensor": ["sensor"]
-                },
-                {
-                    "start_time": "2023-05-24T09:00:00",
-                    "uid": "20230524_0900_file_4_1.nc",
-                    "uri": "/data/20230524_0900_file_4_1.nc",
-                    "sensor": ["sensor"]
+                    "start_time": dt.datetime(2023, 5, 24, 7, 0),
+                    "sensor": ["sensor"],
+                    "platform_name": "FOO-1",
+                    "number": 2,
+                    "dataset": [
+                        {
+                            "uid": "20230524_0700_file_2_1.nc",
+                            "uri": "/data/20230524_0700_file_2_1.nc",
+                        }
+                    ]
                 },
             ]
         }

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -1519,6 +1519,8 @@ class TestTemporalCollection:
 
         assert slot_keys[0] not in segment_gatherer.slots
         assert slot_keys[1] not in segment_gatherer.slots
+        assert slot_keys[2] in segment_gatherer.slots
+        assert slot_keys[3] in segment_gatherer.slots
 
     def test_temporal_collection_publishing(self):
         """Test that metadata for temporal_collection is collected and published correctly."""


### PR DESCRIPTION
This PR adds a way to collect metadata for multiple different configurable time slots and publish them in a single message.

Closes #140 