### PR TITLE
Add SIGTERM handling to segment gatherer

### DIFF
--- a/pytroll_collectors/tests/test_fsspec_to_message.py
+++ b/pytroll_collectors/tests/test_fsspec_to_message.py
@@ -121,8 +121,8 @@ class TestUnpackMessage:
     @pytest.mark.parametrize(
         ("packing", "create_packfile", "filesystem_class"),
         [
-            ("tar", create_tar_file, "fsspec.implementations.tar.TarFileSystem"),
-            ("zip", create_zip_file, "fsspec.implementations.zip.ZipFileSystem"),
+            ("tar", create_tar_file, "fsspec.implementations.tar:TarFileSystem"),
+            ("zip", create_zip_file, "fsspec.implementations.zip:ZipFileSystem"),
         ]
     )
     def test_pack_file_extract(self, packing, create_packfile, filesystem_class, tmp_path):
@@ -153,8 +153,8 @@ class TestUnpackMessage:
     @pytest.mark.parametrize(
         ("packing", "create_packfile", "filesystem_class"),
         [
-            ("tar", create_tar_file, "fsspec.implementations.tar.TarFileSystem"),
-            ("zip", create_zip_file, "fsspec.implementations.zip.ZipFileSystem"),
+            ("tar", create_tar_file, "fsspec.implementations.tar:TarFileSystem"),
+            ("zip", create_zip_file, "fsspec.implementations.zip:ZipFileSystem"),
         ]
     )
     def test_pack_local_file_extract(self, packing, create_packfile, filesystem_class, tmp_path):
@@ -184,8 +184,8 @@ class TestUnpackMessage:
     @pytest.mark.parametrize(
         ("packing", "create_packfile", "filesystem_class"),
         [
-            ("tar", create_tar_file, "fsspec.implementations.tar.TarFileSystem"),
-            ("zip", create_zip_file, "fsspec.implementations.zip.ZipFileSystem"),
+            ("tar", create_tar_file, "fsspec.implementations.tar:TarFileSystem"),
+            ("zip", create_zip_file, "fsspec.implementations.zip:ZipFileSystem"),
         ]
     )
     def test_pack_local_file_extract_filesystem(self, packing, create_packfile, filesystem_class, tmp_path):
@@ -211,8 +211,8 @@ class TestUnpackMessage:
     @pytest.mark.parametrize(
         ("packing", "create_packfile", "filesystem_class"),
         [
-            ("tar", create_tar_file, "fsspec.implementations.tar.TarFileSystem"),
-            ("zip", create_zip_file, "fsspec.implementations.zip.ZipFileSystem"),
+            ("tar", create_tar_file, "fsspec.implementations.tar:TarFileSystem"),
+            ("zip", create_zip_file, "fsspec.implementations.zip:ZipFileSystem"),
         ]
     )
     def test_pack_local_file_extract_with_custom_options(self, packing, create_packfile, filesystem_class, tmp_path):

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,4 @@ tag_prefix = v
 omit =
     pytroll_collectors/_version.py
     versioneer.py
+relative_files = True


### PR DESCRIPTION
This PR adds SIGTERM handling to segment gatherer.

After receiving the signal, the gatherer will wait until all active collections have been finished and then exit the program.