### PR TITLE
Add SIGTERM handling to geographic gatherer

### DIFF
--- a/pytroll_collectors/geographic_gatherer.py
+++ b/pytroll_collectors/geographic_gatherer.py
@@ -108,8 +108,7 @@ class GeographicGatherer:
         """Run granule triggers."""
         signal.signal(signal.SIGTERM, self._handle_sigterm)
         try:
-            while True:
-                self._check_sigterm()
+            while self._keep_running():
                 time.sleep(1)
                 for trigger in self.triggers:
                     if not trigger.is_alive():
@@ -128,13 +127,15 @@ class GeographicGatherer:
         logger.info("Caught SIGTERM, shutting down when all collections are finished.")
         self._sigterm_caught = True
 
-    def _check_sigterm(self):
+    def _keep_running(self):
+        keep_running = True
         if self._sigterm_caught:
+            keep_running = False
             for t in self.triggers:
                 for c in t.collectors:
                     if c.granules:
-                        return
-            raise KeyboardInterrupt("No ongoing collections.")
+                        keep_running = True
+        return keep_running
 
     def stop(self):
         """Stop the gatherer."""

--- a/pytroll_collectors/geographic_gatherer.py
+++ b/pytroll_collectors/geographic_gatherer.py
@@ -138,7 +138,7 @@ class GeographicGatherer:
 
     def stop(self):
         """Stop the gatherer."""
-        logger.info('Ending publication the gathering of granules...')
+        logger.info('Ending the gathering of granules...')
         for trigger in self.triggers:
             trigger.stop()
         self.publisher.stop()

--- a/pytroll_collectors/geographic_gatherer.py
+++ b/pytroll_collectors/geographic_gatherer.py
@@ -130,12 +130,15 @@ class GeographicGatherer:
     def _keep_running(self):
         keep_running = True
         if self._sigterm_caught:
-            keep_running = False
-            for t in self.triggers:
-                for c in t.collectors:
-                    if c.granules:
-                        keep_running = True
+            keep_running = self._trigger_collectors_have_granules()
         return keep_running
+
+    def _trigger_collectors_have_granules(self):
+        for t in self.triggers:
+            for c in t.collectors:
+                if c.granules:
+                    return True
+        return False
 
     def stop(self):
         """Stop the gatherer."""

--- a/pytroll_collectors/tests/test_geographic_gatherer.py
+++ b/pytroll_collectors/tests/test_geographic_gatherer.py
@@ -527,3 +527,27 @@ class TestGeographicGathererWithPosttrollTriggerEndToEnd:
             assert snd_msg.data == expected_msg.data
         finally:
             gatherer.stop()
+
+
+def test_sigterm(tmp_config_file, tmp_config_parser):
+    """Test that SIGTERM signal is handled."""
+    import os
+    import signal
+    import time
+    from multiprocessing import Process
+
+    from pytroll_collectors.geographic_gatherer import GeographicGatherer
+
+    with open(tmp_config_file, mode="w") as fp:
+        tmp_config_parser.write(fp)
+
+    opts = arg_parse(["-c", "minimal_config", "-p", "40000", "-n", "false", "-i", "localhost:12345",
+                     str(tmp_config_file)])
+    gatherer = GeographicGatherer(opts)
+    proc = Process(target=gatherer.run)
+    proc.start()
+    time.sleep(1)
+    os.kill(proc.pid, signal.SIGTERM)
+    proc.join()
+
+    assert proc.exitcode == 0

--- a/pytroll_collectors/tests/test_geographic_gatherer.py
+++ b/pytroll_collectors/tests/test_geographic_gatherer.py
@@ -543,7 +543,9 @@ def test_sigterm(tmp_config_file, tmp_config_parser):
 
     opts = arg_parse(["-c", "minimal_config", "-p", "40000", "-n", "false", "-i", "localhost:12345",
                      str(tmp_config_file)])
-    gatherer = GeographicGatherer(opts)
+    # We don't need the triggers here. They also interfere with completing the test (the test never exits)
+    with patch("pytroll_collectors.geographic_gatherer.TriggerFactory.create"):
+        gatherer = GeographicGatherer(opts)
     proc = Process(target=gatherer.run)
     proc.start()
     time.sleep(1)


### PR DESCRIPTION
This PR adds SIGTERM handling to geographic gatherer.

After receiving the signal, the gatherer will wait until all active collections have been finished and then exit the program.
