### PR TITLE
only drop scheme for file type messages

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -196,7 +196,7 @@ class Message:
 
     def _handle_scheme(self, posttroll_message):
         message_data = posttroll_message.data.copy()
-        if self._drop_scheme:
+        if self._drop_scheme and posttroll_message.type == "file":
             url_parts = urlparse(message_data['uri'])
             uri = urlunparse(
                 (


### PR DESCRIPTION
Limit removing the scheme from the URI to incoming messages of type 'file'.

- [x] Fixes #160 
- [ ] Tests added
- [ ] Documentation added