### PR TITLE
Correct timeliness entry in index.rst

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -342,7 +342,7 @@ patterns
         (Can also be defined globally)
 
 timeliness
-    Time in seconds from the first arrived file until timeout.  When timeout is
+    Time in minutes from the first arrived file until timeout.  When timeout is
     reached, all collected files (meaning all files that match the ``all_files`` pattern)
     are broadcast in a posttroll message.
 


### PR DESCRIPTION
Corrected seconds to minutes under timeliness in segment_gatherer section. 

Proof with sg-config timeliness set to 10:
[DEBUG: 2025-09-16 08:46:27 : segment_gatherer] Adding new slot: 2025-09-16 08:30:00  
[INFO: 2025-09-16 08:46:27 : segment_gatherer] Setting timeout to 2025-09-16 08:56:27.323100 for slot 2025-09-16 08:30:00.