### PR TITLE
Fix end time in segment gatherer

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -52,6 +52,7 @@ from urllib.parse import urlparse, urlunparse
 from pytroll_collectors.utils import check_nameserver_options
 from pytroll_collectors.utils import create_started_publisher_from_config
 from pytroll_collectors.utils import create_publisher_config_dict
+from pytroll_collectors.utils import fix_start_end_time
 
 logger = logging.getLogger("segment_gatherer")
 
@@ -164,10 +165,10 @@ class Message:
         self.pattern = pattern
         self._drop_scheme = drop_scheme
         posttroll_message = self._handle_scheme(posttroll_message)
-        self.message_data = posttroll_message.data
+        self.message_data = fix_start_end_time(posttroll_message.data)
         self.type = posttroll_message.type
         self._posttroll_message = posttroll_message
-        self.metadata = pattern.parser.parse(self.message_data)
+        self.metadata = fix_start_end_time(pattern.parser.parse(self.message_data))
         self._time_name = self.pattern.time_name
         self.adjust_time_by_flooring()
 

--- a/pytroll_collectors/tests/data/segments_noaa20.yaml
+++ b/pytroll_collectors/tests/data/segments_noaa20.yaml
@@ -1,0 +1,23 @@
+patterns:
+  viirs:
+    pattern:
+      "{segment}_{platform_short_name}_d{start_time:%Y%m%d_t%H%M%S}{start_decimal:1d}_e{end_time:%H%M%S}{end_decimal:1d}_b{orbit_number:5d}_c{proctime:s}_cspp_dev.h5"
+    critical_files:
+      ":GITCO,:GMTCO,:GDNBO"
+    wanted_files:
+      ":SVM01,:SVM02,:SVM03,:SVM04,:SVM05,:SVM06,:SVM07,:SVM08,:SVM09,:SVM10,:SVM11,:SVM12,:SVM13,:SVM14,:SVM15,:SVM16,:GMTCO,:SVI01,:SVI02,:SVI03,:SVI04,:SVI05,:GITCO,:SVDNB,:GDNBO"
+    all_files:
+      ":SVM01,:SVM02,:SVM03,:SVM04,:SVM05,:SVM06,:SVM07,:SVM08,:SVM09,:SVM10,:SVM11,:SVM12,:SVM13,:SVM14,:SVM15,:SVM16,:GMTCO,:SVI01,:SVI02,:SVI03,:SVI04,:SVI05,:GITCO,:SVDNB,:GDNBO"
+    variable_tags:
+      - proctime
+
+timeliness:
+  1200
+time_name:
+  start_time
+
+posttroll:
+  topics:
+    - /sogs/noaa-20/L1
+  publish_topic:
+    /sogs/noaa-20/L1/segments

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -50,6 +50,8 @@ CONFIG_INI_NO_SEG = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"),
 CONFIG_INI_HIMAWARI = ini_to_dict(os.path.join(THIS_DIR, "data/segments.ini"),
                                   "himawari-8")
 CONFIG_NWCSAF_GEO = ini_to_dict(os.path.join(THIS_DIR, "data/segments_nwcsaf_geo.ini"), "nwcsaf_geo")
+CONFIG_NOAA20 = read_yaml(os.path.join(THIS_DIR, "data/segments_noaa20.yaml"))
+
 LOGGING_ERROR = logging.ERROR
 
 fake_config = {
@@ -116,7 +118,18 @@ class TestSegmentGatherer:
         self.mda_msg0deg_file_scheme = {"segment": "EPI", "uid": "H-000-MSG3__-MSG3________-_________-EPI______-201611281100-__", "platform_shortname": "MSG3", "start_time": dt.datetime(2016, 11, 28, 11, 0, 0), "nominal_time": dt.datetime(  # noqa
             2016, 11, 28, 11, 0, 0), "uri": "file:///home/lahtinep/data/satellite/geo/msg/H-000-MSG3__-MSG3________-_________-EPI______-201611281100-__", "platform_name": "Meteosat-10", "channel_name": "", "path": "", "sensor": ["seviri"], "hrit_format": "MSG3"}  # noqa
 
-        self.mda_nwcsaf_geo = {"product": "CRR-Ph", "sensor": "nwc_saf_geo", "platform_name": "Meteosat-11", "start_time": dt.datetime(2023, 2, 14, 13, 0, 0), "uri": "file:///data/S_NWC_CRR-Ph_MSG4_MSG-N-VISIR_20230214T130000Z.nc", "uid": "S_NWC_CRR-Ph_MSG4_MSG-N-VISIR_20230214T130000Z.nc"}  # noqa
+        self.mda_nwcsaf_geo = {"product": "CRR-Ph", "sensor": "nwc_saf_geo", "platform_name": "Meteosat-11",
+                               "start_time": dt.datetime(2023, 2, 14, 13, 0, 0),
+                               "uri": "file:///data/S_NWC_CRR-Ph_MSG4_MSG-N-VISIR_20230214T130000Z.nc",
+                               "uid": "S_NWC_CRR-Ph_MSG4_MSG-N-VISIR_20230214T130000Z.nc"}  # noqa
+
+        self.mda_noaa20 = {"sensor": "viirs", "platform_name": "NOAA-20", "segment": "SVM13",
+                           "platform_short_name": "j01", "start_time": dt.datetime(2025, 9, 24, 10, 5, 47),
+                           "start_decimal": 6, "end_time": dt.datetime(1900, 1, 1, 10, 19, 58),
+                           "end_decimal": 5, "orbit_number": 40677,
+                           "proctime": dt.datetime(2025, 9, 24, 3, 13, 28, 998280),
+                           "uri": "/data/SVM13_j01_d20250924_t1005476_e1019585_b40677_c20250924103132899828_cspp_dev.h5",  # noqa
+                           "uid": "SVM13_j01_d20250924_t1005476_e1019585_b40677_c20250924103132899828_cspp_dev.h5"}
 
         self.msg0deg = SegmentGatherer(CONFIG_SINGLE)
         self.msg0deg_north = SegmentGatherer(CONFIG_SINGLE_NORTH)
@@ -126,6 +139,7 @@ class TestSegmentGatherer:
         self.goes_ini = SegmentGatherer(CONFIG_INI_NO_SEG)
         self.himawari_ini = SegmentGatherer(CONFIG_INI_HIMAWARI)
         self.nwcsaf_geo = SegmentGatherer(CONFIG_NWCSAF_GEO)
+        self.noaa20 = SegmentGatherer(CONFIG_NOAA20)
 
     def test_init(self):
         """Test init."""
@@ -263,6 +277,15 @@ class TestSegmentGatherer:
         slot.update_timeout()
         diff = slot['timeout'] - now
         np.testing.assert_almost_equal(diff.total_seconds(), 10.0, decimal=3)
+
+    def test_fix_end_time(self):
+        """Test that end time is fixed so that it is after start time."""
+        import numpy as np
+
+        mda = self.mda_noaa20.copy()
+        fake_message = FakeMessage(mda)
+        message = Message(fake_message, self.noaa20._patterns["viirs"])
+        assert message.metadata["end_time"] == dt.datetime(2025, 9, 24, 10, 19, 58)
 
     def test_slot_is_ready(self):
         """Test if a slot is ready."""

--- a/pytroll_collectors/tests/test_triggers.py
+++ b/pytroll_collectors/tests/test_triggers.py
@@ -56,7 +56,7 @@ class TestPostTrollTrigger:
                                  'format': 'fmt', 'data_processing_level': 'l1b', 'uri': 'uri3'})]
 
         collector = Mock()
-        collector.timeout = dt.datetime.utcnow() + dt.timedelta(seconds=.2)
+        collector.timeout = dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=.2)
         collector.return_value = None
 
         def finish():

--- a/pytroll_collectors/tests/test_triggers.py
+++ b/pytroll_collectors/tests/test_triggers.py
@@ -24,7 +24,7 @@
 """Unittests for triggers."""
 
 import time
-from datetime import datetime, timedelta
+import datetime as dt
 
 from unittest.mock import patch, Mock, call
 import pytest
@@ -56,7 +56,7 @@ class TestPostTrollTrigger:
                                  'format': 'fmt', 'data_processing_level': 'l1b', 'uri': 'uri3'})]
 
         collector = Mock()
-        collector.timeout = datetime.utcnow() + timedelta(seconds=.2)
+        collector.timeout = dt.datetime.utcnow() + dt.timedelta(seconds=.2)
         collector.return_value = None
 
         def finish():
@@ -82,10 +82,10 @@ class TestPostTrollTrigger:
         publisher = Mock()
         ptt = PostTrollTrigger(None, None, None, publisher, duration=60)
 
-        msg_data = ptt._get_metadata(FakeMessage({"a": "a", 'start_time': datetime(2020, 1, 21, 11, 27)}))
+        msg_data = ptt._get_metadata(FakeMessage({"a": "a", 'start_time': dt.datetime(2020, 1, 21, 11, 27)}))
 
         assert "end_time" in msg_data
-        assert msg_data["end_time"] == datetime(2020, 1, 21, 11, 28)
+        assert msg_data["end_time"] == dt.datetime(2020, 1, 21, 11, 28)
 
     @patch('pytroll_collectors.triggers._posttroll.create_subscriber_from_dict_config')
     def test_inbound_connection_is_used(self, nssub):
@@ -232,9 +232,9 @@ class TestFileTrigger:
         res = trigger._get_metadata("somefile_20220512T1544_20220512T1545.data")
 
         assert res == {"name": "somefile",
-                       'end_time': datetime(2022, 5, 12, 15, 45),
+                       'end_time': dt.datetime(2022, 5, 12, 15, 45),
                        'filename': 'somefile_20220512T1544_20220512T1545.data',
-                       'start_time': datetime(2022, 5, 12, 15, 44),
+                       'start_time': dt.datetime(2022, 5, 12, 15, 44),
                        'uri': 'somefile_20220512T1544_20220512T1545.data'
                        }
 
@@ -258,9 +258,9 @@ class TestFileTrigger:
         res = trigger._get_metadata("somefile_20220512T1544_20220512T1545.data")
 
         assert res == {"name": "somefile",
-                       'end_time': datetime(2022, 5, 12, 15, 45),
+                       'end_time': dt.datetime(2022, 5, 12, 15, 45),
                        'filename': 'somefile_20220512T1544_20220512T1545.data',
-                       'start_time': datetime(2022, 5, 12, 15, 44),
+                       'start_time': dt.datetime(2022, 5, 12, 15, 44),
                        'uri': 'somefile_20220512T1544_20220512T1545.data',
                        'key1': "value1"
                        }
@@ -281,12 +281,12 @@ class TestFileTrigger:
         trigger = FileTrigger(collectors, dict(config.items("section1")), publisher, publish_topic=None,
                               publish_message_after_each_reception=False)
         trigger._process_metadata({'sensor': 'avhrr', 'platform_name': 'Metop-B',
-                                   'start_time': datetime(2022, 9, 1, 10, 22, 3),
+                                   'start_time': dt.datetime(2022, 9, 1, 10, 22, 3),
                                    'orbit_number': '51653',
                                    'uri': 'AVHRR_C_EUMP_20220901102203_51653_eps_o_amv_l2d.bin',
                                    'uid': 'AVHRR_C_EUMP_20220901102203_51653_eps_o_amv_l2d.bin',
                                    'origin': '157.249.16.188:9062',
-                                   'end_time': datetime(2022, 9, 1, 10, 25, 3)})
+                                   'end_time': dt.datetime(2022, 9, 1, 10, 25, 3)})
         assert "Found no TLE entry for 'METOP-B' to simulate" in caplog.text
 
     @patch('pytroll_collectors.triggers._base.Trigger.publish_collection')

--- a/pytroll_collectors/triggers/_base.py
+++ b/pytroll_collectors/triggers/_base.py
@@ -200,7 +200,7 @@ class FileTrigger(Trigger, Thread):
                         # but don't clean up the collection as new files will be added until timeout
                         self.publish_collection(next_timeout[0].finish_without_reset())
                     self.new_file.wait(total_seconds(next_timeout[1] -
-                                                     dt.datetime.utcnow()))
+                                                     dt.datetime.now(dt.timezone.utc)))
                     self.new_file.clear()
             else:
                 self.new_file.wait()

--- a/pytroll_collectors/triggers/_base.py
+++ b/pytroll_collectors/triggers/_base.py
@@ -175,7 +175,7 @@ class FileTrigger(Trigger, Thread):
 
             if timeouts:
                 next_timeout = min(timeouts, key=(lambda x: x[1]))
-                if next_timeout[1] and (next_timeout[1] < dt.datetime.utcnow()):
+                if next_timeout[1] and (next_timeout[1] < dt.datetime.now(dt.timezone.utc)):
                     logger.debug("Timeout detected, terminating collector")
                     logger.debug("Area: %s, timeout: %s",
                                  next_timeout[0].region,

--- a/pytroll_collectors/triggers/_base.py
+++ b/pytroll_collectors/triggers/_base.py
@@ -191,7 +191,7 @@ class FileTrigger(Trigger, Thread):
                 else:
                     logger.debug("Waiting %s seconds until timeout",
                                  str(total_seconds(next_timeout[1] -
-                                                   dt.datetime.utcnow())))
+                                                   dt.datetime.now(dt.timezone.utc))))
                     logger.debug("Is last file added: {}".format(next_timeout[0].is_last_file_added()))
                     if self.publish_message_after_each_reception and next_timeout[0].is_last_file_added():
                         # If this option is given:

--- a/pytroll_collectors/triggers/_posttroll.py
+++ b/pytroll_collectors/triggers/_posttroll.py
@@ -30,7 +30,8 @@ import warnings
 
 from posttroll.subscriber import create_subscriber_from_dict_config
 
-from ._base import FileTrigger, fix_start_end_time
+from ._base import FileTrigger
+from pytroll_collectors.utils import fix_start_end_time
 
 logger = logging.getLogger(__name__)
 

--- a/pytroll_collectors/utils.py
+++ b/pytroll_collectors/utils.py
@@ -74,8 +74,9 @@ def fix_start_end_time(mda):
                                               mda["end_time"].time())
         del mda["end_date"]
 
-    while mda["start_time"] > mda["end_time"]:
-        mda["end_time"] += dt.timedelta(days=1)
+    if "end_time" in mda:
+        while mda["start_time"] > mda["end_time"]:
+            mda["end_time"] += dt.timedelta(days=1)
 
     if "duration" in mda:
         del mda["duration"]

--- a/pytroll_collectors/utils.py
+++ b/pytroll_collectors/utils.py
@@ -22,6 +22,8 @@
 
 """Utility functions."""
 
+import datetime as dt
+
 from posttroll.publisher import create_publisher_from_dict_config
 
 
@@ -54,3 +56,28 @@ def create_publisher_config_dict(name, nameservers, port):
         'port': port,
         'nameservers': nameservers,
     }
+
+
+def fix_start_end_time(mda):
+    """Make start and end time coherent."""
+    if "duration" in mda and "end_time" not in mda:
+        mda["end_time"] = (mda["start_time"]
+                           + dt.timedelta(seconds=int(mda["duration"])))
+    if "start_date" in mda:
+        mda["start_time"] = dt.datetime.combine(mda["start_date"].date(),
+                                                mda["start_time"].time())
+        if "end_date" not in mda:
+            mda["end_date"] = mda["start_date"]
+        del mda["start_date"]
+    if "end_date" in mda:
+        mda["end_time"] = dt.datetime.combine(mda["end_date"].date(),
+                                              mda["end_time"].time())
+        del mda["end_date"]
+
+    while mda["start_time"] > mda["end_time"]:
+        mda["end_time"] += dt.timedelta(days=1)
+
+    if "duration" in mda:
+        del mda["duration"]
+
+    return mda


### PR DESCRIPTION
In some cases, like with VIIRS data, the `end_time` does not have the year in the file pattern and thus the date will be set as `1900-01-01` in Segment Gatherer. There is an existing fix in Geographic Gatherer that I here migrate to public method in `utils.py` and adjust a bit to make work also with segment gathering.

I also fixed the `datetime` imports in the files I touched.