### PR TITLE
Switch to `netifaces-plus` and add a workaround to skip unusable network interfaces

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -21,7 +21,6 @@ dependencies:
   - freezegun
   - paramiko
   - responses
-  - netifaces
   - watchdog!=4.0.0
   - s3fs
   - pyinotify
@@ -36,3 +35,4 @@ dependencies:
     - trollsift
     - posttroll
     - pytroll-schedule
+    - netifaces-plus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 [project.optional-dependencies]
 all = [
     "fsspec",
-    "netifaces",
+    "netifaces-plus",
     "pyresample",
     "python-dateutil",
     "pytroll-schedule",
@@ -49,7 +49,7 @@ s3stalker = [
     "s3fs",
 ]
 scisys_receiver = [
-    "netifaces",
+    "netifaces-plus",
 ]
 trollstalker = [
     "watchdog!=4.0.0",

--- a/pytroll_collectors/helper_functions.py
+++ b/pytroll_collectors/helper_functions.py
@@ -150,8 +150,14 @@ def get_local_ips():
     """Get the local ips."""
     import netifaces
 
-    inet_addrs = [netifaces.ifaddresses(iface).get(netifaces.AF_INET)
-                  for iface in netifaces.interfaces()]
+    inet_addrs = []
+    for iface in netifaces.interfaces():
+        try:
+            addr = netifaces.ifaddresses(iface).get(netifaces.AF_INET)
+        except ValueError:
+            pass
+        inet_addrs.append(addr)
+
     ips = []
     for addr in inet_addrs:
         if addr is not None:


### PR DESCRIPTION
The `netifaces` GitHub repository has been archived since 2021. This PR swithces to the somewhat more maintained `netifaces-plus` package that is a fork of the original and a drop-in replacement.

This change was actually triggered by the failure I got in running tests:
```python
>       inet_addrs = [netifaces.ifaddresses(iface).get(netifaces.AF_INET)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                      for iface in netifaces.interfaces()]
E       ValueError: You must specify a valid interface name.
```
In my case this was triggered by `gpd0` interface created by GlobalProtect VPN.

I don't know what would be the best route to test this, mocking the `netifaces.interfaces()` to return "foo" doesn't really sound reasonable.