### PR TITLE
When critical files are missing, log which ones those are.

### DIFF
--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -458,9 +458,11 @@ class Slot:
                 status[key] = Status.SLOT_READY
 
         # Determine overall status
-        return self.get_collection_status(status, self['timeout'])
+        return self.get_collection_status(
+                status, self['timeout'],
+                self[key]["critical_files"] - self[key]["received_files"])
 
-    def get_collection_status(self, status, timeout):
+    def get_collection_status(self, status, timeout, missing_critical=None):
         """Determine the overall status of the collection."""
         if len(status) == 0:
             return Status.SLOT_NOT_READY
@@ -488,8 +490,9 @@ class Slot:
 
             logger.warning("Timeout occured and required files "
                            "were not present, data discarded for "
-                           "slot %s.",
-                           self.timestamp)
+                           "slot %s. "
+                           "Missing critical files: %s.",
+                           self.timestamp, missing_critical)
             return Status.SLOT_OBSOLETE_TIMEOUT
 
         if Status.SLOT_NOT_READY in status_values:

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -787,6 +787,20 @@ class TestSegmentGatherer:
         # Triage after the kill signal takes 1 s
         assert time.time() - tic > 1.
 
+    def test_informative_logging_missing_files(self, caplog):
+        """Test that logging informs what files/filepatterns are missing."""
+        mda = self.mda_msg0deg.copy()
+        slot_str = str(mda["start_time"])
+        fake_message = FakeMessage(mda)
+        message = Message(fake_message, self.msg0deg._patterns['msg'])
+        self.msg0deg._create_slot(message)
+        slot = self.msg0deg.slots[slot_str]
+        slot["timeout"] = dt.datetime.utcnow()
+        with caplog.at_level(logging.WARNING):
+            slot.get_status()
+        assert "Timeout occured and required files were not present" in caplog.text
+        assert "H-000-MSG3__-MSG3________-_________-PRO______-201611281100-__" in caplog.text
+
 
 def _fake_triage_slots(self):
     """Fake the triage_slots() method.


### PR DESCRIPTION
Improve the log message reported when critical files are missing, to inform exactly what critical files are missing.