### PR TITLE
Start cat runner without requiring a nameserver

### DIFF
--- a/pytroll_collectors/scripts/cat.py
+++ b/pytroll_collectors/scripts/cat.py
@@ -232,7 +232,7 @@ def main():
     if 'publish_port' in config:
         publish_port = int(config['publish_port'])
 
-    sub_nameserver = 'localhost'
+    sub_nameserver = False # When False, the subscriber will not try to find a nameserver!
     if 'subscriber_nameserver' in config:
         sub_nameserver = config['subscriber_nameserver']
 

--- a/pytroll_collectors/scripts/cat.py
+++ b/pytroll_collectors/scripts/cat.py
@@ -232,9 +232,9 @@ def main():
     if 'publish_port' in config:
         publish_port = int(config['publish_port'])
 
-    sub_nameserver = False # When False, the subscriber will not try to find a nameserver!
-    if 'subscriber_nameserver' in config:
-        sub_nameserver = config['subscriber_nameserver']
+    sub_nameserver = config.get('subscriber_nameserver', "localhost")
+    if sub_nameserver.lower() == "false":
+        sub_nameserver = False
 
     sub_addresses = None
     if 'subscriber_addresses' in config:


### PR DESCRIPTION
Make it possible to disable subscriber nameserver in `cat.py`.