### PR TITLE
Allow fractional collection periods in Segment Gatherer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
           pytest --cov=pytroll_collectors pytroll_collectors/tests --cov-report=xml
 
       - name: Upload unittest coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           flags: unittests
           files: ./coverage.xml

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Create sdist and wheel
         shell: bash -l {0}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -335,7 +335,7 @@ class Slot:
 
     def update_timeout(self):
         """Update the timeout."""
-        timeout = dt.datetime.utcnow() + self._timeliness
+        timeout = dt.datetime.now(dt.timezone.utc) + self._timeliness
         self['timeout'] = timeout
         logger.info("Setting timeout to %s for slot %s.",
                     str(timeout), self.timestamp)
@@ -358,7 +358,7 @@ class Slot:
         timeout = self['timeout']
         if len(slot_pattern['critical_files']) > 0 and \
            slot_pattern['critical_files'].issubset(slot_pattern['received_files']):
-            delay = dt.datetime.utcnow() - (timeout - self._timeliness)
+            delay = dt.datetime.now(dt.timezone.utc) - (timeout - self._timeliness)
             if delay.total_seconds() > 0:
                 slot_pattern['delayed_files'][uid] = delay.total_seconds()
 
@@ -468,7 +468,7 @@ class Slot:
                         "for slot %s.", self.timestamp)
             return Status.SLOT_READY
 
-        if dt.datetime.utcnow() > timeout:
+        if dt.datetime.now(dt.timezone.utc) > timeout:
             if (Status.SLOT_NONCRITICAL_NOT_READY in status_values and
                 (Status.SLOT_READY in status_values or
                     Status.SLOT_READY_BUT_WAIT_FOR_MORE in status_values)):

--- a/pytroll_collectors/segments.py
+++ b/pytroll_collectors/segments.py
@@ -189,11 +189,10 @@ class Message:
         if group_by_minutes is None:
             return
         time_item = metadata[time_name]
-        minutes = time_item.minute
-        floor_minutes = int(minutes / group_by_minutes) * group_by_minutes
-        time_item = dt.datetime(time_item.year, time_item.month,
-                                time_item.day, time_item.hour, floor_minutes, 0)
-        metadata[time_name] = time_item
+        seconds_this_year = (time_item - dt.datetime(time_item.year, 1, 1)).total_seconds()
+        group_by_seconds = dt.timedelta(minutes=group_by_minutes).total_seconds()
+        rounded_seconds = seconds_this_year - (seconds_this_year % group_by_seconds)
+        metadata[time_name] = dt.datetime(time_item.year, 1, 1) + dt.timedelta(seconds=rounded_seconds)
 
     def _handle_scheme(self, posttroll_message):
         message_data = posttroll_message.data.copy()
@@ -244,8 +243,7 @@ class Slot:
             self.output_metadata.pop('dataset', None)
         for (key, pattern) in patterns.items():
             if len(patterns) > 1:
-                self.output_metadata['collection'][key] = \
-                    {'dataset': [], 'sensor': []}
+                self.output_metadata['collection'][key] = {'dataset': [], 'sensor': []}
             self[key] = self.create_slot_pattern(pattern)
 
         self.update_timeout()
@@ -333,7 +331,6 @@ class Slot:
                 fname = parser.globify(meta)
 
                 result.add(fname)
-
         return result
 
     def update_timeout(self):

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -250,7 +250,7 @@ class TestSegmentGatherer:
         fake_message = FakeMessage(mda)
         message = Message(fake_message, self.msg0deg._patterns['msg'])
         self.msg0deg._create_slot(message)
-        now = dt.datetime.utcnow()
+        now = dt.datetime.now(dt.timezone.utc)
         slot = self.msg0deg.slots[slot_str]
         slot.update_timeout()
         diff = slot['timeout'] - now
@@ -313,7 +313,7 @@ class TestSegmentGatherer:
         mda = self.mda_msg0deg.copy()
         slot_str = str(mda["start_time"])
 
-        now = dt.datetime.utcnow()
+        now = dt.datetime.now(dt.timezone.utc)
         future = now + dt.timedelta(minutes=1)
         past = now - dt.timedelta(minutes=1)
 

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -1247,21 +1247,36 @@ class TestSegmentGathererCollections:
         """Test that end_time is correct in message."""
         config = fake_config.copy()
         config["group_by_minutes"] = 2.5
+        config["patterns"]["oak"]["wanted_files"] = ":001-005"
+        config["patterns"]["oak"]["all_files"] = ":001-005"
+
         sg = SegmentGatherer(config)
+
+        segments = [(1, 0, 0), (2, 0, 30), (3, 1, 0), (4, 1, 30), (5, 2, 0),
+                    (1, 2, 30), (2, 3, 0), (3, 3, 30), (4, 4, 0), (5, 4, 30),
+                    (None, 5, 0),
+                    ]
         rawstrs = []
-        for mm, ss in (("02", "30"), ("05", "00"), ("07", "30")):
-            rawstr=f"pytroll://tree/oak file pytroll@forest 1980-01-01T13:0{mm}:{ss}.000000 v1.01 application/json "
-                   f'{{"platform_name": "forest", "start_time": "1980-01-01T13:{mm}:{ss}", "end_time": '
-                   f'"1980-01-01T13:0{i+1:d}:00", "uri": "/data/oak-s19800101130{i:d}00-e19800101130{i+1:d}00-'
-                   f's00{i:d}.tree", "uid": "oak-s19800101130{i:d}00-e19800101130{i+1:d}00-s00{i:d}.tree", '
-                   '"sensor": "Thaumetopoea processionea"}')
-                for i in range(3)]
-        messages = [posttroll.message.Message(rawstr) for rawstr in rawstrs]
+        for i, (seg, mm, ss) in enumerate(segments):
+            if seg is None:
+                break
+            end_mm = segments[i+1][1]
+            end_ss = segments[i+1][2]
+            rawstrs.append(
+                "pytroll://tree/oak file pytroll@forest "
+                f"1980-01-01T13:{end_mm:02d}:{end_ss:02d}.000000 v1.01 application/json "
+                f'{{"platform_name": "forest", '
+                f'"start_time": "1980-01-01T13:{mm:02d}:{ss:02d}", '
+                f'"end_time": "1980-01-01T13:{end_mm:02d}:{end_ss:02d}", '
+                f'"uri": "/data/oak-s1980010113{mm:02d}{ss:02d}-e1980010113{end_mm:02d}{end_ss:02d}-s00{seg:d}.tree", '
+                f'"uid": "oak-s1980010113{mm:02d}{ss:02d}-e1980010113{end_mm:02d}{end_ss:02d}-s00{seg:d}.tree", '
+                '"sensor": "Thaumetopoea processionea"}')
+        messages = [posttroll.message.Message(rawstr=rawstr) for rawstr in rawstrs]
         for msg in messages:
             sg.process(msg)
-        assert len(sg.slots) == 1
+        assert len(sg.slots) == 2
         assert sg.slots["1980-01-01 13:00:00"].output_metadata["start_time"] == dt.datetime(1980, 1, 1, 13, 0, 0)
-        assert sg.slots["1980-01-01 13:00:00"].output_metadata["end_time"] == dt.datetime(1980, 1, 1, 13, 3, 0)
+        assert sg.slots["1980-01-01 13:00:00"].output_metadata["end_time"] == dt.datetime(1980, 1, 1, 13, 2, 30)
 
 
 pps_message1 = ('pytroll://segment/CF/2/CMA/norrkoping/utv/polar/direct_readout/ file safusr.u@lxserv1043.smhi.se '
@@ -1550,7 +1565,6 @@ def test_remote_file_with_filesystem_passes_filesystem_info(filesystem):
         segment_gatherer.process(msg)
 
     timestamp = '2025-06-26 07:30:00'
-    print(segment_gatherer.slots)
     assert timestamp in segment_gatherer.slots
     storage_options = dict(cls="fsspec.implementations.sftp:SFTPFileSystem",
                            protocol="sftp",

--- a/pytroll_collectors/tests/test_segments.py
+++ b/pytroll_collectors/tests/test_segments.py
@@ -1243,6 +1243,27 @@ class TestSegmentGathererCollections:
         assert sg.slots["1980-01-01 13:00:00"].output_metadata["end_time"] == dt.datetime(1980, 1, 1, 13, 3, 0)
 
 
+    def test_end_time_correct_group_by_fractional_minutes(self):
+        """Test that end_time is correct in message."""
+        config = fake_config.copy()
+        config["group_by_minutes"] = 2.5
+        sg = SegmentGatherer(config)
+        rawstrs = []
+        for mm, ss in (("02", "30"), ("05", "00"), ("07", "30")):
+            rawstr=f"pytroll://tree/oak file pytroll@forest 1980-01-01T13:0{mm}:{ss}.000000 v1.01 application/json "
+                   f'{{"platform_name": "forest", "start_time": "1980-01-01T13:{mm}:{ss}", "end_time": '
+                   f'"1980-01-01T13:0{i+1:d}:00", "uri": "/data/oak-s19800101130{i:d}00-e19800101130{i+1:d}00-'
+                   f's00{i:d}.tree", "uid": "oak-s19800101130{i:d}00-e19800101130{i+1:d}00-s00{i:d}.tree", '
+                   '"sensor": "Thaumetopoea processionea"}')
+                for i in range(3)]
+        messages = [posttroll.message.Message(rawstr) for rawstr in rawstrs]
+        for msg in messages:
+            sg.process(msg)
+        assert len(sg.slots) == 1
+        assert sg.slots["1980-01-01 13:00:00"].output_metadata["start_time"] == dt.datetime(1980, 1, 1, 13, 0, 0)
+        assert sg.slots["1980-01-01 13:00:00"].output_metadata["end_time"] == dt.datetime(1980, 1, 1, 13, 3, 0)
+
+
 pps_message1 = ('pytroll://segment/CF/2/CMA/norrkoping/utv/polar/direct_readout/ file safusr.u@lxserv1043.smhi.se '
                 '2020-10-16T08:01:59.035595 v1.01 application/json {"module": "ppsCmask", "pps_version": "v2018", '
                 '"platform_name": "NOAA-20", "orbit": 15081, "sensor": "viirs", "start_time": '


### PR DESCRIPTION
Currently Segment Gatherer is limited to collection periods for full minutes (e.g. 5/10/15 minutes). This PR adds the possibility to collect also to sub-minute periods, having the 2.5 minute repeat-cycle of MTG RSS in mind. The use of `datetime` objects came from AI, but the implementation it suggested didn't work (use of `%` modulo operator on `datetime` and `timedelta`), so I wrote the actual implementation myself.

I've also removed the deprecated use of `dt.datetime.utcnow()` from Segment Gatherer and its tests.