### PR TITLE
Fix the sigterm tests

### DIFF
--- a/pytroll_collectors/geographic_gatherer.py
+++ b/pytroll_collectors/geographic_gatherer.py
@@ -1,5 +1,6 @@
 """Geographic segment gathering."""
 
+from multiprocessing import Event
 import logging
 import signal
 import time
@@ -33,7 +34,7 @@ class GeographicGatherer:
         self.triggers = []
         self.return_status = 0
 
-        self._sigterm_caught = False
+        self._sigterm_caught = Event()
 
         self._clean_config()
         self._setup_publisher()
@@ -101,11 +102,11 @@ class GeographicGatherer:
 
     def _handle_sigterm(self, signum, frame):
         logger.info("Caught SIGTERM, shutting down when all collections are finished.")
-        self._sigterm_caught = True
+        self._sigterm_caught.set()
 
     def _keep_running(self):
         keep_running = True
-        if self._sigterm_caught:
+        if self._sigterm_caught.is_set():
             keep_running = self._trigger_collectors_have_granules()
         return keep_running
 

--- a/pytroll_collectors/tests/test_geographic_gatherer.py
+++ b/pytroll_collectors/tests/test_geographic_gatherer.py
@@ -523,7 +523,7 @@ def test_sigterm(tmp_config_file, tmp_config_parser, section):
     import os
     import signal
     import time
-    from multiprocessing import get_context, Process
+    from multiprocessing import Process
 
     from pytroll_collectors.geographic_gatherer import GeographicGatherer
 

--- a/pytroll_collectors/tests/test_geographic_gatherer.py
+++ b/pytroll_collectors/tests/test_geographic_gatherer.py
@@ -506,51 +506,32 @@ class TestGeographicGathererWithPosttrollTriggerEndToEnd:
             gatherer.stop()
 
 
-def test_sigterm(tmp_config_file, tmp_config_parser):
+def _run_gatherer(filename, section):
+    from pytroll_collectors.geographic_gatherer import GeographicGatherer
+
+    opts = arg_parse(["-c", section, "-p", "40002", "-n", "false", "-i", "localhost:12345",
+                     filename])
+    # We don't need the triggers here. They also interfere with completing the test (the test never exits)
+    with patch("pytroll_collectors.geographic_gatherer.TriggerFactory.create"):
+        gatherer = GeographicGatherer(opts)
+        gatherer.run()
+
+
+@pytest.mark.parametrize("section", ["minimal_config", "posttroll_section"])
+def test_sigterm(tmp_config_file, tmp_config_parser, section):
     """Test that SIGTERM signal is handled."""
     import os
     import signal
     import time
-    from multiprocessing import Process
+    from multiprocessing import get_context, Process
 
     from pytroll_collectors.geographic_gatherer import GeographicGatherer
 
     with open(tmp_config_file, mode="w") as fp:
         tmp_config_parser.write(fp)
 
-    opts = arg_parse(["-c", "minimal_config", "-p", "40000", "-n", "false", "-i", "localhost:12345",
-                     str(tmp_config_file)])
-    # We don't need the triggers here. They also interfere with completing the test (the test never exits)
-    with patch("pytroll_collectors.geographic_gatherer.TriggerFactory.create"):
-        gatherer = GeographicGatherer(opts)
-    proc = Process(target=gatherer.run)
-    proc.start()
-    time.sleep(1)
-    os.kill(proc.pid, signal.SIGTERM)
-    proc.join()
-
-    assert proc.exitcode == 0
-
-
-def test_sigterm_with_collection(tmp_config_file, tmp_config_parser):
-    """Test that SIGTERM signal is handled when there is collection ongoing."""
-    import os
-    import signal
-    import time
-    from multiprocessing import Process
-
-    from pytroll_collectors.geographic_gatherer import GeographicGatherer
-
-    with open(tmp_config_file, mode="w") as fp:
-        tmp_config_parser.write(fp)
-
-    opts = arg_parse(["-c", "posttroll_section", "-p", "40000", "-n", "false", "-i", "localhost:12345",
-                     str(tmp_config_file)])
-    # Use a fake trigger that initially sets some granules and after a while clears them
-    with patch("pytroll_collectors.geographic_gatherer.PostTrollTrigger",
-               new=FakeTriggerWithGranules):
-        gatherer = GeographicGatherer(opts)
-    proc = Process(target=gatherer.run)
+    filename = str(tmp_config_file)
+    proc = Process(target=_run_gatherer, args=[filename, section])
     proc.start()
     time.sleep(1)
     os.kill(proc.pid, signal.SIGTERM)


### PR DESCRIPTION
Python has become much more sensitive when forking, we need to take that into account when creating an external process for testing.

This in turn lead to neverending tests because the new posttroll authenticator thread (zmq) was never started.